### PR TITLE
Add occlusion toggle for lattice cage visualization

### DIFF
--- a/Editor/LatticeTool.cs
+++ b/Editor/LatticeTool.cs
@@ -33,6 +33,7 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
         private static bool s_mirrorEditing = false;
         private static MirrorAxis s_mirrorAxis = MirrorAxis.X;
         private static MirrorBehavior s_mirrorBehavior = MirrorBehavior.Mirrored;
+        private static bool s_occludeWithSceneGeometry = true;
         private static PivotRotation? s_previousPivotRotation;
         private static Vector3Int s_lastGridSize = Vector3Int.one;
 
@@ -62,6 +63,21 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                 }
 
                 s_showIndices = value;
+                SceneView.RepaintAll();
+            }
+        }
+
+        internal static bool OccludeWithSceneGeometry
+        {
+            get => s_occludeWithSceneGeometry;
+            set
+            {
+                if (s_occludeWithSceneGeometry == value)
+                {
+                    return;
+                }
+
+                s_occludeWithSceneGeometry = value;
                 SceneView.RepaintAll();
             }
         }
@@ -240,7 +256,7 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
             }
 
             var previousZTest = Handles.zTest;
-            Handles.zTest = CompareFunction.LessEqual;
+            Handles.zTest = OccludeWithSceneGeometry ? CompareFunction.LessEqual : CompareFunction.Always;
 
             if (MirrorEditing)
             {
@@ -652,6 +668,12 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                     });
                 bool includeInterior = scopeSelection == 1;
                 LatticeDeformerTool.IncludeInteriorControls = includeInterior;
+                GUILayout.Space(2f);
+
+                LatticeDeformerTool.OccludeWithSceneGeometry = GUILayout.Toggle(
+                    LatticeDeformerTool.OccludeWithSceneGeometry,
+                    LatticeLocalization.Content("Occlude Lattice Cage"));
+
                 GUILayout.Space(2f);
 
                 using (new GUILayout.HorizontalScope())

--- a/Editor/LatticeTool.cs
+++ b/Editor/LatticeTool.cs
@@ -672,7 +672,7 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
 
                 LatticeDeformerTool.OccludeWithSceneGeometry = GUILayout.Toggle(
                     LatticeDeformerTool.OccludeWithSceneGeometry,
-                    LatticeLocalization.Content("Occlude Lattice Cage"));
+                    LatticeLocalization.Content("Hide cage behind scene objects"));
 
                 GUILayout.Space(2f);
 

--- a/Editor/LatticeTool.cs
+++ b/Editor/LatticeTool.cs
@@ -670,9 +670,10 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                 LatticeDeformerTool.IncludeInteriorControls = includeInterior;
                 GUILayout.Space(2f);
 
-                LatticeDeformerTool.OccludeWithSceneGeometry = GUILayout.Toggle(
-                    LatticeDeformerTool.OccludeWithSceneGeometry,
-                    LatticeLocalization.Content("Hide cage behind scene objects"));
+                bool keepControlsVisible = GUILayout.Toggle(
+                    !LatticeDeformerTool.OccludeWithSceneGeometry,
+                    LatticeLocalization.Content("Keep control points visible through objects"));
+                LatticeDeformerTool.OccludeWithSceneGeometry = !keepControlsVisible;
 
                 GUILayout.Space(2f);
 

--- a/Editor/Localization/en.po
+++ b/Editor/Localization/en.po
@@ -54,8 +54,8 @@ msgstr "Boundary Only"
 msgid "All Controls"
 msgstr "All Controls"
 
-msgid "Hide cage behind scene objects"
-msgstr "Hide cage behind scene objects"
+msgid "Keep control points visible through objects"
+msgstr "Keep control points visible through objects"
 
 msgid "Clear Selection"
 msgstr "Clear Selection"

--- a/Editor/Localization/en.po
+++ b/Editor/Localization/en.po
@@ -54,6 +54,9 @@ msgstr "Boundary Only"
 msgid "All Controls"
 msgstr "All Controls"
 
+msgid "Occlude Lattice Cage"
+msgstr "Occlude Lattice Cage"
+
 msgid "Clear Selection"
 msgstr "Clear Selection"
 

--- a/Editor/Localization/en.po
+++ b/Editor/Localization/en.po
@@ -54,8 +54,8 @@ msgstr "Boundary Only"
 msgid "All Controls"
 msgstr "All Controls"
 
-msgid "Occlude Lattice Cage"
-msgstr "Occlude Lattice Cage"
+msgid "Hide cage behind scene objects"
+msgstr "Hide cage behind scene objects"
 
 msgid "Clear Selection"
 msgstr "Clear Selection"

--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -54,8 +54,8 @@ msgstr "境界のみ"
 msgid "All Controls"
 msgstr "全制御点"
 
-msgid "Hide cage behind scene objects"
-msgstr "シーンのオブジェクトの裏ではケージを隠す"
+msgid "Keep control points visible through objects"
+msgstr "オブジェクトで制御点を隠さない"
 
 msgid "Clear Selection"
 msgstr "選択をクリア"

--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -54,6 +54,9 @@ msgstr "境界のみ"
 msgid "All Controls"
 msgstr "全制御点"
 
+msgid "Occlude Lattice Cage"
+msgstr "ラティスケージをシーンオブジェクトで隠す"
+
 msgid "Clear Selection"
 msgstr "選択をクリア"
 

--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -54,8 +54,8 @@ msgstr "境界のみ"
 msgid "All Controls"
 msgstr "全制御点"
 
-msgid "Occlude Lattice Cage"
-msgstr "ラティスケージをシーンオブジェクトで隠す"
+msgid "Hide cage behind scene objects"
+msgstr "シーンのオブジェクトの裏ではケージを隠す"
 
 msgid "Clear Selection"
 msgstr "選択をクリア"

--- a/Editor/Localization/ko.po
+++ b/Editor/Localization/ko.po
@@ -54,8 +54,8 @@ msgstr "경계만"
 msgid "All Controls"
 msgstr "모든 제어점"
 
-msgid "Hide cage behind scene objects"
-msgstr "다른 오브젝트 뒤에 있을 때 케이지 숨기기"
+msgid "Keep control points visible through objects"
+msgstr "오브젝트 뒤에서도 제어점이 보이도록 유지"
 
 msgid "Clear Selection"
 msgstr "선택 지우기"

--- a/Editor/Localization/ko.po
+++ b/Editor/Localization/ko.po
@@ -54,6 +54,9 @@ msgstr "경계만"
 msgid "All Controls"
 msgstr "모든 제어점"
 
+msgid "Occlude Lattice Cage"
+msgstr "씬 오브젝트로 래티스 케이지 가리기"
+
 msgid "Clear Selection"
 msgstr "선택 지우기"
 

--- a/Editor/Localization/ko.po
+++ b/Editor/Localization/ko.po
@@ -54,8 +54,8 @@ msgstr "경계만"
 msgid "All Controls"
 msgstr "모든 제어점"
 
-msgid "Occlude Lattice Cage"
-msgstr "씬 오브젝트로 래티스 케이지 가리기"
+msgid "Hide cage behind scene objects"
+msgstr "다른 오브젝트 뒤에 있을 때 케이지 숨기기"
 
 msgid "Clear Selection"
 msgstr "선택 지우기"

--- a/Editor/Localization/zh-Hans.po
+++ b/Editor/Localization/zh-Hans.po
@@ -54,6 +54,9 @@ msgstr "仅边界"
 msgid "All Controls"
 msgstr "全部控制点"
 
+msgid "Occlude Lattice Cage"
+msgstr "让场景物体遮挡格子笼"
+
 msgid "Clear Selection"
 msgstr "清除选择"
 

--- a/Editor/Localization/zh-Hans.po
+++ b/Editor/Localization/zh-Hans.po
@@ -54,8 +54,8 @@ msgstr "仅边界"
 msgid "All Controls"
 msgstr "全部控制点"
 
-msgid "Occlude Lattice Cage"
-msgstr "让场景物体遮挡格子笼"
+msgid "Hide cage behind scene objects"
+msgstr "被场景物体挡住时隐藏笼架"
 
 msgid "Clear Selection"
 msgstr "清除选择"

--- a/Editor/Localization/zh-Hans.po
+++ b/Editor/Localization/zh-Hans.po
@@ -54,8 +54,8 @@ msgstr "仅边界"
 msgid "All Controls"
 msgstr "全部控制点"
 
-msgid "Hide cage behind scene objects"
-msgstr "被场景物体挡住时隐藏笼架"
+msgid "Keep control points visible through objects"
+msgstr "物体不会遮挡控制点"
 
 msgid "Clear Selection"
 msgstr "清除选择"

--- a/Editor/Localization/zh-Hant.po
+++ b/Editor/Localization/zh-Hant.po
@@ -54,8 +54,8 @@ msgstr "僅邊界"
 msgid "All Controls"
 msgstr "全部控制點"
 
-msgid "Occlude Lattice Cage"
-msgstr "讓場景物件遮蔽晶格籠"
+msgid "Hide cage behind scene objects"
+msgstr "被場景物件遮擋時隱藏籠架"
 
 msgid "Clear Selection"
 msgstr "清除選取"

--- a/Editor/Localization/zh-Hant.po
+++ b/Editor/Localization/zh-Hant.po
@@ -54,6 +54,9 @@ msgstr "僅邊界"
 msgid "All Controls"
 msgstr "全部控制點"
 
+msgid "Occlude Lattice Cage"
+msgstr "讓場景物件遮蔽晶格籠"
+
 msgid "Clear Selection"
 msgstr "清除選取"
 

--- a/Editor/Localization/zh-Hant.po
+++ b/Editor/Localization/zh-Hant.po
@@ -54,8 +54,8 @@ msgstr "僅邊界"
 msgid "All Controls"
 msgstr "全部控制點"
 
-msgid "Hide cage behind scene objects"
-msgstr "被場景物件遮擋時隱藏籠架"
+msgid "Keep control points visible through objects"
+msgstr "物件不會遮住控制點"
 
 msgid "Clear Selection"
 msgstr "清除選取"


### PR DESCRIPTION
## Summary
- add an option to toggle depth occlusion for the lattice cage handles
- expose the occlusion toggle in the Lattice Tool overlay UI
- localize the new control label across all supported languages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbad4f42c83339a05dfcc93720327)