### PR TITLE
Prevent selection change while editing lattice box

### DIFF
--- a/Editor/LatticeTool.cs
+++ b/Editor/LatticeTool.cs
@@ -211,6 +211,9 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                 return;
             }
 
+            // Prevent selection from switching away from the current lattice while editing.
+            HandleUtility.AddDefaultControl(GUIUtility.GetControlID(FocusType.Passive));
+
             DrawControlHandles(deformer, settings, controlCount);
         }
 


### PR DESCRIPTION
## Summary
- prevent selection changes when using the lattice tool by consuming scene view events

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbbedf9b48333bf170eaed22b0782)