### PR TITLE
feat: Enhance Lattice Deformation Tool with alignment settings and proxy renderer support

### DIFF
--- a/Editor/LatticeDeformerPreviewFilter.cs
+++ b/Editor/LatticeDeformerPreviewFilter.cs
@@ -159,6 +159,8 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                         continue;
                     }
 
+                    LatticePreviewUtility.RegisterProxy(original, proxy);
+
                     var target = new Target
                     {
                         OriginalRenderer = original,
@@ -206,6 +208,8 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                     {
                         continue;
                     }
+
+                    LatticePreviewUtility.ClearProxy(target.OriginalRenderer);
 
                     if (target.ProxyMeshFilter != null)
                     {
@@ -292,6 +296,8 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                 {
                     return null;
                 }
+
+                LatticePreviewUtility.RegisterProxy(original, proxy);
 
                 var target = new Target
                 {

--- a/Editor/LatticePreviewUtility.cs
+++ b/Editor/LatticePreviewUtility.cs
@@ -1,11 +1,18 @@
 #if UNITY_EDITOR
+using System.Collections.Generic;
 using nadena.dev.ndmf.preview;
 using UnityEditor;
+using UnityEngine;
+using Net._32Ba.LatticeDeformationTool;
 
 namespace Net._32Ba.LatticeDeformationTool.Editor
 {
     internal static class LatticePreviewUtility
     {
+        private const string k_PreviewAlignedKey = "Net32Ba.LatticeDeformer.UsePreviewAlignedCage";
+        private const string k_DebugAlignKey = "Net32Ba.LatticeDeformer.DebugAlignLogs";
+        private static readonly Dictionary<Renderer, Renderer> s_latestProxyMap = new();
+
         /// <summary>
         /// Determines whether the runtime mesh should be assigned back to the renderer.
         /// When the NDMF preview pipeline is active we leave the original mesh untouched
@@ -26,9 +33,254 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
             return !LatticeDeformerPreviewFilter.PreviewToggleEnabled;
         }
 
+        /// <summary>
+        /// Whether to align lattice editing handles to the NDMF preview proxy transform (if any).
+        /// Stored in EditorPrefs so it is per-user.
+        /// </summary>
+        public static bool UsePreviewAlignedCage
+        {
+            get => EditorPrefs.GetBool(k_PreviewAlignedKey, false);
+            set => EditorPrefs.SetBool(k_PreviewAlignedKey, value);
+        }
+
+        /// <summary>
+        /// Whether to apply bounds-based remapping when aligning to proxy. Off by default to avoid doubleスケール.
+        /// </summary>
+
+        public static bool DebugAlignLogs
+        {
+            get => EditorPrefs.GetBool(k_DebugAlignKey, false);
+            set => EditorPrefs.SetBool(k_DebugAlignKey, value);
+        }
+
+        // Per-instance getters
+        public static LatticeDeformer.LatticeAlignMode GetAlignMode(LatticeDeformer deformer) =>
+            deformer != null ? deformer.AlignMode : LatticeDeformer.LatticeAlignMode.Mode3_BoundsRemap;
+
+        public static float GetCenterClampMulXY(LatticeDeformer deformer) =>
+            deformer != null ? deformer.CenterClampMulXY : 0f;
+
+        public static float GetCenterClampMinXY(LatticeDeformer deformer) =>
+            deformer != null ? deformer.CenterClampMinXY : 0f;
+
+        public static float GetCenterClampMulZ(LatticeDeformer deformer) =>
+            deformer != null ? deformer.CenterClampMulZ : 0f;
+
+        public static float GetCenterClampMinZ(LatticeDeformer deformer) =>
+            deformer != null ? deformer.CenterClampMinZ : 0f;
+
+        public static bool GetAllowCenterOffsetWhenSkipped(LatticeDeformer deformer) =>
+            deformer != null && deformer.AllowCenterOffsetWhenBoundsSkipped;
+
+        public static Vector3 GetManualOffsetProxy(LatticeDeformer deformer) =>
+            deformer != null ? deformer.ManualOffsetProxy : Vector3.zero;
+
+        public static Vector3 GetManualScaleProxy(LatticeDeformer deformer) =>
+            deformer != null ? deformer.ManualScaleProxy : Vector3.one;
+
+        /// <summary>
+        /// Returns the transform used for lattice editing. If preview alignment is enabled and a proxy
+        /// renderer exists, its transform is used; otherwise the deformer.MeshTransform is returned.
+        /// </summary>
+        public static Transform GetEditingTransform(LatticeDeformer deformer)
+        {
+            if (deformer == null)
+            {
+                return null;
+            }
+
+            if (UsePreviewAlignedCage)
+            {
+                var renderer = deformer.GetComponent<Renderer>();
+                if (renderer != null)
+                {
+                    if (TryGetRegisteredProxy(renderer, out var proxy) && proxy != null)
+                    {
+                        return proxy.transform;
+                    }
+
+                    if (NDMFPreviewProxyUtility.TryGetProxyRenderer(renderer, out proxy) && proxy != null)
+                    {
+                        return proxy.transform;
+                    }
+                }
+            }
+
+            return deformer.MeshTransform;
+        }
+
+        /// <summary>
+        /// Returns the bounds to use for editing handles. When preview alignment is enabled and a proxy
+        /// renderer exists, this returns the proxy's bounds converted into the editing transform's local space;
+        /// otherwise it returns the source bounds unchanged.
+        /// </summary>
+        public static Bounds GetEditingBounds(LatticeDeformer deformer, Bounds sourceBounds, Transform editingTransform)
+        {
+            if (!UsePreviewAlignedCage || deformer == null)
+            {
+                return sourceBounds;
+            }
+
+            var renderer = deformer.GetComponent<Renderer>();
+            if (renderer == null)
+            {
+                return sourceBounds;
+            }
+
+            if (!NDMFPreviewProxyUtility.TryGetProxyRenderer(renderer, out var proxy) || proxy == null)
+            {
+                return sourceBounds;
+            }
+
+            var targetTransform = editingTransform != null ? editingTransform : proxy.transform;
+            if (targetTransform == null)
+            {
+                return sourceBounds;
+            }
+
+            var worldBounds = GetRendererWorldBounds(proxy);
+            return ToLocalBounds(targetTransform, worldBounds);
+        }
+
+        private static Bounds GetRendererWorldBounds(Renderer proxy)
+        {
+            // Prefer mesh local bounds to avoid inflated SkinnedMeshRenderer.bounds
+            if (proxy is SkinnedMeshRenderer skinned && skinned.sharedMesh != null)
+            {
+                return TransformMeshBounds(skinned.sharedMesh.bounds, proxy.transform);
+            }
+
+            if (proxy is MeshRenderer meshRenderer)
+            {
+                var mf = meshRenderer.GetComponent<MeshFilter>();
+                if (mf != null && mf.sharedMesh != null)
+                {
+                    return TransformMeshBounds(mf.sharedMesh.bounds, proxy.transform);
+                }
+            }
+
+            return proxy.bounds;
+        }
+
+        private static Bounds TransformMeshBounds(Bounds localBounds, Transform transform)
+        {
+            var center = transform.TransformPoint(localBounds.center);
+            var extents = localBounds.extents;
+            var right = transform.TransformVector(extents.x, 0f, 0f);
+            var up = transform.TransformVector(0f, extents.y, 0f);
+            var fwd = transform.TransformVector(0f, 0f, extents.z);
+
+            var worldExtents = new Vector3(
+                Mathf.Abs(right.x) + Mathf.Abs(up.x) + Mathf.Abs(fwd.x),
+                Mathf.Abs(right.y) + Mathf.Abs(up.y) + Mathf.Abs(fwd.y),
+                Mathf.Abs(right.z) + Mathf.Abs(up.z) + Mathf.Abs(fwd.z));
+
+            return new Bounds(center, worldExtents * 2f);
+        }
+
+        private static Bounds ToLocalBounds(Transform target, Bounds worldBounds)
+        {
+            if (target == null)
+            {
+                return worldBounds;
+            }
+
+            var center = target.InverseTransformPoint(worldBounds.center);
+
+            // Transform extents by inverse rotation/scale using absolute axes
+            var extents = worldBounds.extents;
+            var right = target.InverseTransformVector(new Vector3(extents.x, 0f, 0f));
+            var up = target.InverseTransformVector(new Vector3(0f, extents.y, 0f));
+            var forward = target.InverseTransformVector(new Vector3(0f, 0f, extents.z));
+
+            var localExtents = new Vector3(
+                Mathf.Abs(right.x) + Mathf.Abs(up.x) + Mathf.Abs(forward.x),
+                Mathf.Abs(right.y) + Mathf.Abs(up.y) + Mathf.Abs(forward.y),
+                Mathf.Abs(right.z) + Mathf.Abs(up.z) + Mathf.Abs(forward.z));
+
+            return new Bounds(center, localExtents * 2f);
+        }
+
         public static void RequestSceneRepaint()
         {
             SceneView.RepaintAll();
+        }
+
+        internal static void RegisterProxy(Renderer original, Renderer proxy)
+        {
+            if (original == null || proxy == null)
+            {
+                return;
+            }
+
+            s_latestProxyMap[original] = proxy;
+        }
+
+        internal static void ClearProxy(Renderer original)
+        {
+            if (original == null)
+            {
+                return;
+            }
+
+            s_latestProxyMap.Remove(original);
+        }
+
+        internal static void LogAlign(string tag, string msg)
+        {
+            if (!DebugAlignLogs) return;
+            Debug.Log($"[LatticeAlign] {tag}: {msg}");
+        }
+
+        private static bool TryGetRegisteredProxy(Renderer original, out Renderer proxy)
+        {
+            return s_latestProxyMap.TryGetValue(original, out proxy);
+        }
+
+        internal static Bounds GetMeshLocalBounds(Renderer renderer)
+        {
+            if (renderer == null)
+            {
+                return new Bounds(Vector3.zero, Vector3.zero);
+            }
+
+            switch (renderer)
+            {
+                case SkinnedMeshRenderer skinned:
+                    // localBounds is the skinned renderer's evaluated local AABB (reflects root bone & import settings)
+                    return skinned.localBounds;
+                case MeshRenderer meshRenderer:
+                    var mf = meshRenderer.GetComponent<MeshFilter>();
+                    if (mf != null && mf.sharedMesh != null)
+                    {
+                        return mf.sharedMesh.bounds;
+                    }
+                    break;
+            }
+
+            return renderer.bounds;
+        }
+
+        internal static Bounds GetRendererLocalBounds(Renderer renderer)
+        {
+            if (renderer == null)
+            {
+                return new Bounds(Vector3.zero, Vector3.zero);
+            }
+
+            var world = renderer.bounds;
+            var t = renderer.transform;
+            var center = t.InverseTransformPoint(world.center);
+            var ext = world.extents;
+            var right = t.InverseTransformVector(new Vector3(ext.x, 0f, 0f));
+            var up = t.InverseTransformVector(new Vector3(0f, ext.y, 0f));
+            var fwd = t.InverseTransformVector(new Vector3(0f, 0f, ext.z));
+            var localExt = new Vector3(
+                Mathf.Abs(right.x) + Mathf.Abs(up.x) + Mathf.Abs(fwd.x),
+                Mathf.Abs(right.y) + Mathf.Abs(up.y) + Mathf.Abs(fwd.y),
+                Mathf.Abs(right.z) + Mathf.Abs(up.z) + Mathf.Abs(fwd.z));
+
+            return new Bounds(center, localExt * 2f);
         }
     }
 }

--- a/Editor/Localization/en.po
+++ b/Editor/Localization/en.po
@@ -90,6 +90,53 @@ msgstr "Mesh Rebuild Options"
 msgid "(NDMF) Disable Lattice Preview"
 msgstr "(NDMF) Disable Lattice Preview"
 
+# Alignment settings
+msgid "Lattice Cage Alignment"
+msgstr "Lattice Cage Alignment"
+
+msgid "(NDMF) Alignment Mode"
+msgstr "(NDMF) Alignment Mode"
+msgid "Choose how preview proxy is mapped: Mode1=Transform, Mode2=Transform+Center offset, Mode3=Bounds remap"
+msgstr "Choose how preview proxy is mapped: Mode1=Transform, Mode2=Transform+Center offset, Mode3=Bounds remap"
+msgid "Mode 1"
+msgstr "Mode 1"
+msgid "Mode 2"
+msgstr "Mode 2"
+msgid "Mode 3"
+msgstr "Mode 3"
+msgid "Transform only (uses proxy transform, no bounds remap)"
+msgstr "Transform only (uses proxy transform, no bounds remap)"
+msgid "Transform + center offset (adds center delta)"
+msgstr "Transform + center offset (adds center delta)"
+msgid "Bounds remap (maps lattice bounds to proxy bounds)"
+msgstr "Bounds remap (maps lattice bounds to proxy bounds)"
+
+msgid "Mode1: Transform only\nMode2: Transform + Center offset (clamped)\nMode3: Bounds remap + Center offset"
+msgstr "Mode1: Transform only\nMode2: Transform + Center offset (clamped)\nMode3: Bounds remap + Center offset"
+
+msgid "Manual Offset (proxy local)"
+msgstr "Manual Offset (proxy local)"
+
+msgid "Direct offset applied in proxy local space before auto center / clamp"
+msgstr "Direct offset applied in proxy local space before auto center / clamp"
+
+msgid "Manual Scale (proxy local)"
+msgstr "Manual Scale (proxy local)"
+
+msgid "(NDMF) Allow Center Offset when Bounds Skipped"
+msgstr "(NDMF) Allow Center Offset when Bounds Skipped"
+
+msgid "Alignment Auto-Initialized"
+msgstr "Alignment Auto-Initialized"
+
+msgid "(Debug) Log Preview Alignment to Console"
+msgstr "(Debug) Log Preview Alignment to Console"
+
+msgid "Auto Apply Offset/Scale"
+msgstr "Auto Apply Offset/Scale"
+
+msgid "Manual Only / Auto Offset / Auto Scale / Auto Offset+Scale"
+msgstr "Manual Only / Auto Offset / Auto Scale / Auto Offset+Scale"
 msgid "(NDMF) Enable Lattice Preview"
 msgstr "(NDMF) Enable Lattice Preview"
 
@@ -131,3 +178,10 @@ msgstr "Reset Lattice Cage"
 
 
 
+msgid "Offset"
+msgstr "Offset"
+
+msgid "Scale"
+msgstr "Scale"
+msgid "Position/scale here only move the editing cage in the Scene view. They do not change the deform target\'s bounds or final mesh deformation."
+msgstr "Position/scale here only move the editing cage in the Scene view. They do not change the deform target's bounds or final mesh deformation."

--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -88,6 +88,47 @@ msgstr "メッシュ再構築オプション"
 msgid "(NDMF) Disable Lattice Preview"
 msgstr "(NDMF) Disable Lattice Preview"
 
+# アライン設定
+msgid "Lattice Cage Alignment"
+msgstr "ラティスケージ位置調整"
+
+msgid "(NDMF) Alignment Mode"
+msgstr "(NDMF) アラインメントモード"
+
+msgid "Mode1: Transform only\nMode2: Transform + Center offset (clamped)\nMode3: Bounds remap + Center offset"
+msgstr "Mode1: Transform のみ\nMode2: Transform + センターオフセット(クランプ)\nMode3: Bounds リマップ + センターオフセット"
+
+msgid "Manual Offset (proxy local)"
+msgstr "手動オフセット (プロキシローカル)"
+
+msgid "Direct offset applied in proxy local space before auto center / clamp"
+msgstr "自動センター/クランプの前にプロキシローカルで直接適用されるオフセット"
+
+msgid "Manual Scale (proxy local)"
+msgstr "手動スケール (プロキシローカル)"
+
+msgid "(NDMF) Allow Center Offset when Bounds Skipped"
+msgstr "(NDMF) Bounds 無効時もセンターオフセットを許可"
+
+msgid "Alignment Auto-Initialized"
+msgstr "アライン自動初期化済み"
+
+msgid "(Debug) Log Preview Alignment to Console"
+msgstr "(Debug) プレビューアラインをコンソールにログ出力"
+
+msgid "Auto Apply Offset/Scale"
+msgstr "オフセット／スケール自動適用"
+
+msgid "Manual Only / Auto Offset / Auto Scale / Auto Offset+Scale"
+msgstr "手動のみ／オフセット自動／スケール自動／オフセット＋スケール自動"
+
+# Scale axis labels
+msgid "X"
+msgstr "X"
+msgid "Y"
+msgstr "Y"
+msgid "Z"
+msgstr "Z"
 msgid "(NDMF) Enable Lattice Preview"
 msgstr "(NDMF) Enable Lattice Preview"
 
@@ -128,3 +169,30 @@ msgstr "ラティスケージをリセット"
 
 
 
+msgid "Choose how preview proxy is mapped: Mode1=Transform, Mode2=Transform+Center offset, Mode3=Bounds remap"
+msgstr "プレビュープロキシの合わせ方を選択: モード1=Transform, モード2=Transform+中心オフセット, モード3=Boundsリマップ"
+
+msgid "Mode 1"
+msgstr "モード1"
+
+msgid "Mode 2"
+msgstr "モード2"
+
+msgid "Mode 3"
+msgstr "モード3"
+
+msgid "Transform only (uses proxy transform, no bounds remap)"
+msgstr "Transform のみ（プロキシのTransformを使用、バウンズリマップなし）"
+
+msgid "Transform + center offset (adds center delta)"
+msgstr "Transform + 中心オフセット（中心差分を加算）"
+
+msgid "Bounds remap (maps lattice bounds to proxy bounds)"
+msgstr "Bounds リマップ（ラティスのバウンズをプロキシのバウンズへ写像）"
+msgid "Offset"
+msgstr "オフセット"
+
+msgid "Scale"
+msgstr "スケール"
+msgid "Position/scale here only move the editing cage in the Scene view. They do not change the deform target\'s bounds or final mesh deformation."
+msgstr "ここで設定する位置・スケールはシーン上の編集用ケージだけを動かします。変形対象メッシュのバウンズや最終変形には影響しません。"

--- a/Editor/Localization/ko.po
+++ b/Editor/Localization/ko.po
@@ -88,6 +88,47 @@ msgstr "메시 재구성 옵션"
 msgid "(NDMF) Disable Lattice Preview"
 msgstr "(NDMF) Disable Lattice Preview"
 
+# Alignment settings
+msgid "Lattice Cage Alignment"
+msgstr "라티스 케이지 정렬"
+
+msgid "(NDMF) Alignment Mode"
+msgstr "(NDMF) 정렬 모드"
+
+msgid "Mode1: Transform only\nMode2: Transform + Center offset (clamped)\nMode3: Bounds remap + Center offset"
+msgstr "Mode1: Transform만 사용\nMode2: Transform + 중심 오프셋(클램프)\nMode3: Bounds 리맵 + 중심 오프셋"
+
+msgid "Manual Offset (proxy local)"
+msgstr "수동 오프셋 (프록시 로컬)"
+
+msgid "Direct offset applied in proxy local space before auto center / clamp"
+msgstr "자동 센터/클램프 전에 프록시 로컬 공간에 직접 적용되는 오프셋"
+
+msgid "Manual Scale (proxy local)"
+msgstr "수동 스케일 (프록시 로컬)"
+
+msgid "(NDMF) Allow Center Offset when Bounds Skipped"
+msgstr "(NDMF) Bounds를 건너뛸 때도 중심 오프셋 허용"
+
+msgid "Alignment Auto-Initialized"
+msgstr "정렬 자동 초기화됨"
+
+msgid "(Debug) Log Preview Alignment to Console"
+msgstr "(Debug) 프리뷰 정렬을 콘솔에 로그"
+
+msgid "Auto Apply Offset/Scale"
+msgstr "오프셋/스케일 자동 적용"
+
+msgid "Manual Only / Auto Offset / Auto Scale / Auto Offset+Scale"
+msgstr "수동만 / 오프셋 자동 / 스케일 자동 / 오프셋+스케일 자동"
+
+# Scale axis labels
+msgid "X"
+msgstr "X"
+msgid "Y"
+msgstr "Y"
+msgid "Z"
+msgstr "Z"
 msgid "(NDMF) Enable Lattice Preview"
 msgstr "(NDMF) Enable Lattice Preview"
 
@@ -128,3 +169,30 @@ msgstr "래티스 케이지 초기화"
 
 
 
+msgid "Choose how preview proxy is mapped: Mode1=Transform, Mode2=Transform+Center offset, Mode3=Bounds remap"
+msgstr "프리뷰 프록시를 어떻게 맞출지 선택: 모드1=트랜스폼, 모드2=트랜스폼+센터 오프셋, 모드3=바운즈 리맵"
+
+msgid "Mode 1"
+msgstr "모드 1"
+
+msgid "Mode 2"
+msgstr "모드 2"
+
+msgid "Mode 3"
+msgstr "모드 3"
+
+msgid "Transform only (uses proxy transform, no bounds remap)"
+msgstr "트랜스폼만 사용(프록시 트랜스폼 적용, 바운즈 리맵 없음)"
+
+msgid "Transform + center offset (adds center delta)"
+msgstr "트랜스폼 + 중심 오프셋(센터 차이를 추가)"
+
+msgid "Bounds remap (maps lattice bounds to proxy bounds)"
+msgstr "바운즈 리맵(라티스 바운즈를 프록시 바운즈에 매핑)"
+msgid "Offset"
+msgstr "오프셋"
+
+msgid "Scale"
+msgstr "스케일"
+msgid "Position/scale here only move the editing cage in the Scene view. They do not change the deform target\'s bounds or final mesh deformation."
+msgstr "여기서 설정한 위치/스케일은 씬 뷰의 편집용 케이지만 이동합니다. 변형 대상 메시의 바운즈나 최종 변형에는 영향을 주지 않습니다."

--- a/Editor/Localization/zh-Hans.po
+++ b/Editor/Localization/zh-Hans.po
@@ -88,6 +88,47 @@ msgstr "网格重建选项"
 msgid "(NDMF) Disable Lattice Preview"
 msgstr "(NDMF) Disable Lattice Preview"
 
+# Alignment settings
+msgid "Lattice Cage Alignment"
+msgstr "格架笼对齐"
+
+msgid "(NDMF) Alignment Mode"
+msgstr "(NDMF) 对齐模式"
+
+msgid "Mode1: Transform only\nMode2: Transform + Center offset (clamped)\nMode3: Bounds remap + Center offset"
+msgstr "模式1: 仅Transform\n模式2: Transform + 中心偏移(限制)\n模式3: Bounds重映射 + 中心偏移"
+
+msgid "Manual Offset (proxy local)"
+msgstr "手动偏移 (代理局部)"
+
+msgid "Direct offset applied in proxy local space before auto center / clamp"
+msgstr "在自动中心/限制前应用于代理局部空间的直接偏移"
+
+msgid "Manual Scale (proxy local)"
+msgstr "手动缩放 (代理局部)"
+
+msgid "(NDMF) Allow Center Offset when Bounds Skipped"
+msgstr "(NDMF) 略过Bounds时允许中心偏移"
+
+msgid "Alignment Auto-Initialized"
+msgstr "对齐已自动初始化"
+
+msgid "(Debug) Log Preview Alignment to Console"
+msgstr "(Debug) 将预览对齐输出到控制台"
+
+msgid "Auto Apply Offset/Scale"
+msgstr "自动应用偏移/缩放"
+
+msgid "Manual Only / Auto Offset / Auto Scale / Auto Offset+Scale"
+msgstr "仅手动 / 自动偏移 / 自动缩放 / 自动偏移+缩放"
+
+# Scale axis labels
+msgid "X"
+msgstr "X"
+msgid "Y"
+msgstr "Y"
+msgid "Z"
+msgstr "Z"
 msgid "(NDMF) Enable Lattice Preview"
 msgstr "(NDMF) Enable Lattice Preview"
 
@@ -128,3 +169,30 @@ msgstr "重置晶格笼"
 
 
 
+msgid "Choose how preview proxy is mapped: Mode1=Transform, Mode2=Transform+Center offset, Mode3=Bounds remap"
+msgstr "选择预览代理的对齐方式：模式1=仅变换，模式2=变换+中心偏移，模式3=包围盒重映射"
+
+msgid "Mode 1"
+msgstr "模式1"
+
+msgid "Mode 2"
+msgstr "模式2"
+
+msgid "Mode 3"
+msgstr "模式3"
+
+msgid "Transform only (uses proxy transform, no bounds remap)"
+msgstr "仅变换（使用代理的变换，不做包围盒重映射）"
+
+msgid "Transform + center offset (adds center delta)"
+msgstr "变换+中心偏移（添加中心差）"
+
+msgid "Bounds remap (maps lattice bounds to proxy bounds)"
+msgstr "包围盒重映射（将格笼包围盒映射到代理包围盒）"
+msgid "Offset"
+msgstr "偏移"
+
+msgid "Scale"
+msgstr "缩放"
+msgid "Position/scale here only move the editing cage in the Scene view. They do not change the deform target\'s bounds or final mesh deformation."
+msgstr "此处设置的位置/缩放仅影响场景视图中的编辑笼，不会改变变形目标的包围盒或最终变形结果。"

--- a/Editor/Localization/zh-Hant.po
+++ b/Editor/Localization/zh-Hant.po
@@ -88,6 +88,47 @@ msgstr "網格重建選項"
 msgid "(NDMF) Disable Lattice Preview"
 msgstr "(NDMF) Disable Lattice Preview"
 
+# Alignment settings
+msgid "Lattice Cage Alignment"
+msgstr "格架籠對齊"
+
+msgid "(NDMF) Alignment Mode"
+msgstr "(NDMF) 對齊模式"
+
+msgid "Mode1: Transform only\nMode2: Transform + Center offset (clamped)\nMode3: Bounds remap + Center offset"
+msgstr "模式1: 僅Transform\n模式2: Transform + 中心偏移(限制)\n模式3: Bounds重映射 + 中心偏移"
+
+msgid "Manual Offset (proxy local)"
+msgstr "手動偏移 (代理區域)"
+
+msgid "Direct offset applied in proxy local space before auto center / clamp"
+msgstr "在自動中心/限制前套用於代理區域的偏移"
+
+msgid "Manual Scale (proxy local)"
+msgstr "手動縮放 (代理區域)"
+
+msgid "(NDMF) Allow Center Offset when Bounds Skipped"
+msgstr "(NDMF) 略過Bounds時允許中心偏移"
+
+msgid "Alignment Auto-Initialized"
+msgstr "對齊已自動初始化"
+
+msgid "(Debug) Log Preview Alignment to Console"
+msgstr "(Debug) 將預覽對齊輸出到控制台"
+
+msgid "Auto Apply Offset/Scale"
+msgstr "自動套用偏移/縮放"
+
+msgid "Manual Only / Auto Offset / Auto Scale / Auto Offset+Scale"
+msgstr "僅手動 / 自動偏移 / 自動縮放 / 自動偏移+縮放"
+
+# Scale axis labels
+msgid "X"
+msgstr "X"
+msgid "Y"
+msgstr "Y"
+msgid "Z"
+msgstr "Z"
 msgid "(NDMF) Enable Lattice Preview"
 msgstr "(NDMF) Enable Lattice Preview"
 
@@ -128,3 +169,30 @@ msgstr "重設晶格籠"
 
 
 
+msgid "Choose how preview proxy is mapped: Mode1=Transform, Mode2=Transform+Center offset, Mode3=Bounds remap"
+msgstr "選擇預覽代理的對齊方式：模式1=僅變換，模式2=變換+中心偏移，模式3=包圍盒重新映射"
+
+msgid "Mode 1"
+msgstr "模式1"
+
+msgid "Mode 2"
+msgstr "模式2"
+
+msgid "Mode 3"
+msgstr "模式3"
+
+msgid "Transform only (uses proxy transform, no bounds remap)"
+msgstr "僅變換（使用代理的Transform，不做包圍盒重新映射）"
+
+msgid "Transform + center offset (adds center delta)"
+msgstr "變換+中心偏移（加上中心差值）"
+
+msgid "Bounds remap (maps lattice bounds to proxy bounds)"
+msgstr "包圍盒重新映射（將格籠包圍盒映射到代理包圍盒）"
+msgid "Offset"
+msgstr "偏移"
+
+msgid "Scale"
+msgstr "縮放"
+msgid "Position/scale here only move the editing cage in the Scene view. They do not change the deform target\'s bounds or final mesh deformation."
+msgstr "此處的位移/縮放僅移動場景檢視中的編輯籠，不會改變變形目標的包圍盒或最終變形。"

--- a/Editor/NDMFPreviewProxyUtility.cs
+++ b/Editor/NDMFPreviewProxyUtility.cs
@@ -1,0 +1,328 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace Net._32Ba.LatticeDeformationTool.Editor
+{
+    /// <summary>
+    /// Reflection-based helpers to access NDMF preview proxy renderers.
+    /// Supports properties/fields containing "OriginalToProxy*" and a fallback
+    /// method call GetProxyRenderer(Renderer).
+    /// </summary>
+    internal static class NDMFPreviewProxyUtility
+    {
+        private const BindingFlags k_BindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+
+        public static bool TryGetProxyRenderer(Renderer original, out Renderer proxy)
+        {
+            proxy = null;
+            if (original == null)
+            {
+                return false;
+            }
+
+            foreach (var (orig, prox) in GetOriginalToProxyPairs())
+            {
+                if (orig == null || prox == null)
+                {
+                    continue;
+                }
+
+                if (ReferenceEquals(orig, original) || orig.gameObject == original.gameObject)
+                {
+                    proxy = prox;
+                    return true;
+                }
+            }
+
+            return TryInvokeProxyLookup(original, out proxy);
+        }
+
+        private static bool TryInvokeProxyLookup(Renderer original, out Renderer proxy)
+        {
+            proxy = null;
+            var session = GetCurrentSession();
+            if (session == null)
+            {
+                return false;
+            }
+
+            var type = session.GetType();
+            var method = type.GetMethod("GetProxyRenderer", k_BindingFlags, null, new[] { typeof(Renderer) }, null);
+            if (method == null)
+            {
+                foreach (var m in type.GetMethods(k_BindingFlags))
+                {
+                    if (!m.Name.Contains("Proxy", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    var parameters = m.GetParameters();
+                    if (parameters.Length != 1 || m.ReturnType != typeof(Renderer))
+                    {
+                        continue;
+                    }
+
+                    method = m;
+                    break;
+                }
+            }
+
+            if (method == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                proxy = method.Invoke(session, new object[] { original }) as Renderer;
+                return proxy != null;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static IEnumerable<(Renderer original, Renderer proxy)> GetOriginalToProxyPairs()
+        {
+            var session = GetCurrentSession();
+            if (session == null)
+            {
+                yield break;
+            }
+
+            foreach (var member in EnumerateProxyMapMembers(session))
+            {
+                object value = null;
+                try
+                {
+                    value = member switch
+                    {
+                        PropertyInfo p => p.GetValue(session),
+                        FieldInfo f => f.GetValue(session),
+                        _ => null
+                    };
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (value == null)
+                {
+                    continue;
+                }
+
+                foreach (var pair in ExtractPairs(value))
+                {
+                    yield return pair;
+                }
+            }
+
+            // Fallback: if no members matched, attempt method-based lookup for renderer/object maps.
+            foreach (var pair in EnumerateProxyPairsFromMethods(session))
+            {
+                yield return pair;
+            }
+        }
+
+        private static IEnumerable<(Renderer original, Renderer proxy)> EnumerateProxyPairsFromMethods(object session)
+        {
+            if (session == null)
+            {
+                yield break;
+            }
+
+            var type = session.GetType();
+            foreach (var method in type.GetMethods(k_BindingFlags))
+            {
+                if (!method.Name.Contains("GetOriginalToProxy", StringComparison.OrdinalIgnoreCase) &&
+                    !method.Name.Contains("OriginalToProxy", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Expect zero-arg returning dictionary-like object.
+                if (method.GetParameters().Length != 0)
+                {
+                    continue;
+                }
+
+                object value = null;
+                try
+                {
+                    value = method.Invoke(session, null);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (value == null)
+                {
+                    continue;
+                }
+
+                foreach (var pair in ExtractPairs(value))
+                {
+                    yield return pair;
+                }
+            }
+        }
+
+        private static IEnumerable<(Renderer original, Renderer proxy)> ExtractPairs(object value)
+        {
+            if (value is IDictionary dict)
+            {
+                foreach (DictionaryEntry entry in dict)
+                {
+                    if (TryBuildPair(entry.Key, entry.Value, out var pair))
+                    {
+                        yield return pair;
+                    }
+                }
+                yield break;
+            }
+
+            if (value is IEnumerable enumerable)
+            {
+                foreach (var item in enumerable)
+                {
+                    if (item == null)
+                    {
+                        continue;
+                    }
+
+                    var type = item.GetType();
+                    var keyProp = type.GetProperty("Key");
+                    var valueProp = type.GetProperty("Value");
+                    if (keyProp == null || valueProp == null)
+                    {
+                        continue;
+                    }
+
+                    var keyObj = keyProp.GetValue(item);
+                    var valObj = valueProp.GetValue(item);
+                    if (TryBuildPair(keyObj, valObj, out var pair))
+                    {
+                        yield return pair;
+                    }
+                }
+            }
+        }
+
+        private static bool TryBuildPair(object keyObj, object valObj, out (Renderer, Renderer) pair)
+        {
+            pair = (null, null);
+            var keyRenderer = ExtractRenderer(keyObj);
+            var valRenderer = ExtractRenderer(valObj);
+            if (keyRenderer != null && valRenderer != null)
+            {
+                pair = (keyRenderer, valRenderer);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static Renderer ExtractRenderer(object obj)
+        {
+            switch (obj)
+            {
+                case Renderer r:
+                    return r;
+                case Component c:
+                    return c.GetComponent<Renderer>();
+                case GameObject go:
+                    return go.GetComponent<Renderer>();
+                default:
+                    return null;
+            }
+        }
+
+        private static IEnumerable<MemberInfo> EnumerateProxyMapMembers(object session)
+        {
+            if (session == null)
+            {
+                yield break;
+            }
+
+            var type = session.GetType();
+
+            bool IsCandidate(string name) => name.IndexOf("OriginalToProxy", StringComparison.OrdinalIgnoreCase) >= 0;
+
+            foreach (var prop in type.GetProperties(k_BindingFlags))
+            {
+                if (IsCandidate(prop.Name))
+                {
+                    yield return prop;
+                }
+            }
+
+            foreach (var field in type.GetFields(k_BindingFlags))
+            {
+                if (IsCandidate(field.Name))
+                {
+                    yield return field;
+                }
+            }
+        }
+
+        private static object GetCurrentSession()
+        {
+            var type = FindPreviewSessionType();
+            if (type == null)
+            {
+                return null;
+            }
+
+            var prop = type.GetProperty("Current", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            if (prop == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return prop.GetValue(null);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static Type FindPreviewSessionType()
+        {
+            var type = Type.GetType("nadena.dev.ndmf.preview.PreviewSession, nadena.dev.ndmf.preview");
+            if (type != null)
+            {
+                return type;
+            }
+
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+                    type = asm.GetType("nadena.dev.ndmf.preview.PreviewSession");
+                    if (type != null)
+                    {
+                        return type;
+                    }
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+
+            return null;
+        }
+    }
+}
+#endif

--- a/Editor/NDMFPreviewProxyUtility.cs.meta
+++ b/Editor/NDMFPreviewProxyUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa80eedbbed5812468ea3dda04b25061
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Added alignment modes to LatticeDeformer for improved proxy mapping: Transform only, Transform + Center offset, and Bounds remap.
- Introduced manual offset and scale settings for proxy local space.
- Implemented NDMFPreviewProxyUtility to facilitate access to proxy renderers using reflection.
- Updated LatticeTool to utilize new alignment features and proxy renderer adjustments.
- Enhanced localization files for new alignment settings and descriptions in English, Japanese, Korean, and Chinese.