### PR TITLE
refactor: 保守性の向上

### DIFF
--- a/Editor/LatticeBoundsUtility.cs
+++ b/Editor/LatticeBoundsUtility.cs
@@ -1,0 +1,106 @@
+#if UNITY_EDITOR
+using UnityEngine;
+
+namespace Net._32Ba.LatticeDeformationTool.Editor
+{
+    /// <summary>
+    /// Shared utility methods for bounds calculations used across the Lattice Deformation Tool.
+    /// </summary>
+    internal static class LatticeBoundsUtility
+    {
+        /// <summary>
+        /// Divides the bounds center and size by the given scale.
+        /// Used to convert scaled bounds back to unscaled local space.
+        /// </summary>
+        /// <param name="bounds">The bounds to divide.</param>
+        /// <param name="scale">The scale to divide by.</param>
+        /// <returns>A new Bounds with center and size divided by scale.</returns>
+        public static Bounds DivideByScale(Bounds bounds, Vector3 scale)
+        {
+            var center = new Vector3(
+                scale.x != 0f ? bounds.center.x / scale.x : bounds.center.x,
+                scale.y != 0f ? bounds.center.y / scale.y : bounds.center.y,
+                scale.z != 0f ? bounds.center.z / scale.z : bounds.center.z);
+
+            var size = new Vector3(
+                scale.x != 0f ? bounds.size.x / Mathf.Abs(scale.x) : bounds.size.x,
+                scale.y != 0f ? bounds.size.y / Mathf.Abs(scale.y) : bounds.size.y,
+                scale.z != 0f ? bounds.size.z / Mathf.Abs(scale.z) : bounds.size.z);
+
+            return new Bounds(center, size);
+        }
+
+        /// <summary>
+        /// Checks if two bounds are approximately equal within a relative tolerance.
+        /// </summary>
+        /// <param name="a">First bounds.</param>
+        /// <param name="b">Second bounds.</param>
+        /// <param name="relativeTolerance">Tolerance relative to bounds size.</param>
+        /// <returns>True if bounds are approximately equal.</returns>
+        public static bool AreApproximatelyEqual(Bounds a, Bounds b, float relativeTolerance)
+        {
+            float tolX = Mathf.Abs(a.size.x) * relativeTolerance + 1e-5f;
+            float tolY = Mathf.Abs(a.size.y) * relativeTolerance + 1e-5f;
+            float tolZ = Mathf.Abs(a.size.z) * relativeTolerance + 1e-5f;
+
+            return Mathf.Abs(a.size.x - b.size.x) <= tolX &&
+                   Mathf.Abs(a.size.y - b.size.y) <= tolY &&
+                   Mathf.Abs(a.size.z - b.size.z) <= tolZ;
+        }
+
+        /// <summary>
+        /// Creates a new bounds that encompasses both input bounds.
+        /// </summary>
+        /// <param name="a">First bounds.</param>
+        /// <param name="b">Second bounds.</param>
+        /// <returns>A bounds that contains both input bounds.</returns>
+        public static Bounds Encapsulate(Bounds a, Bounds b)
+        {
+            var min = Vector3.Min(a.min, b.min);
+            var max = Vector3.Max(a.max, b.max);
+            return new Bounds((min + max) * 0.5f, max - min);
+        }
+
+        /// <summary>
+        /// Maps a point from one bounds space to another.
+        /// </summary>
+        /// <param name="point">The point to map.</param>
+        /// <param name="from">Source bounds.</param>
+        /// <param name="to">Target bounds.</param>
+        /// <returns>The point mapped to the target bounds space.</returns>
+        public static Vector3 MapPointBetweenBounds(Vector3 point, Bounds from, Bounds to)
+        {
+            var fromSize = from.size;
+            var toSize = to.size;
+
+            float nx = fromSize.x != 0f ? (point.x - from.min.x) / fromSize.x : 0f;
+            float ny = fromSize.y != 0f ? (point.y - from.min.y) / fromSize.y : 0f;
+            float nz = fromSize.z != 0f ? (point.z - from.min.z) / fromSize.z : 0f;
+
+            return new Vector3(
+                to.min.x + nx * toSize.x,
+                to.min.y + ny * toSize.y,
+                to.min.z + nz * toSize.z);
+        }
+
+        /// <summary>
+        /// Maps a delta vector from one bounds space to another.
+        /// </summary>
+        /// <param name="delta">The delta to map.</param>
+        /// <param name="from">Source bounds.</param>
+        /// <param name="to">Target bounds.</param>
+        /// <returns>The delta mapped to the target bounds space.</returns>
+        public static Vector3 MapDeltaBetweenBounds(Vector3 delta, Bounds from, Bounds to)
+        {
+            var fromSize = from.size;
+            var toSize = to.size;
+
+            float sx = fromSize.x != 0f ? toSize.x / fromSize.x : 0f;
+            float sy = fromSize.y != 0f ? toSize.y / fromSize.y : 0f;
+            float sz = fromSize.z != 0f ? toSize.z / fromSize.z : 0f;
+
+            return new Vector3(delta.x * sx, delta.y * sy, delta.z * sz);
+        }
+    }
+}
+#endif

--- a/Editor/LatticeDeformerEditor.cs
+++ b/Editor/LatticeDeformerEditor.cs
@@ -594,21 +594,6 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
             EditorGUI.EndProperty();
         }
 
-        private static Bounds DivBoundsByScale(Bounds b, Vector3 scale)
-        {
-            var center = new Vector3(
-                scale.x != 0f ? b.center.x / scale.x : b.center.x,
-                scale.y != 0f ? b.center.y / scale.y : b.center.y,
-                scale.z != 0f ? b.center.z / scale.z : b.center.z);
-
-            var size = new Vector3(
-                scale.x != 0f ? b.size.x / Mathf.Abs(scale.x) : b.size.x,
-                scale.y != 0f ? b.size.y / Mathf.Abs(scale.y) : b.size.y,
-                scale.z != 0f ? b.size.z / Mathf.Abs(scale.z) : b.size.z);
-
-            return new Bounds(center, size);
-        }
-
         private static void EnsureLinkIcons()
         {
             if (s_linkOn == null)

--- a/Editor/LatticeDeformerPreviewFilter.cs
+++ b/Editor/LatticeDeformerPreviewFilter.cs
@@ -352,8 +352,9 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                 previewMesh.UploadMeshData(false);
                 return previewMesh;
             }
-            catch
+            catch (System.Exception ex)
             {
+                Debug.LogWarning($"[LatticeDeformer] Failed to generate preview mesh: {ex.Message}");
                 return null;
             }
         }

--- a/Editor/NDMFPreviewProxyUtility.cs
+++ b/Editor/NDMFPreviewProxyUtility.cs
@@ -82,8 +82,12 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                 proxy = method.Invoke(session, new object[] { original }) as Renderer;
                 return proxy != null;
             }
-            catch
+            catch (Exception ex)
             {
+                if (LatticePreviewUtility.DebugAlignLogs)
+                {
+                    Debug.LogWarning($"[LatticeProxyUtility] Failed to invoke proxy lookup: {ex.Message}");
+                }
                 return false;
             }
         }
@@ -108,8 +112,12 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                         _ => null
                     };
                 }
-                catch
+                catch (Exception ex)
                 {
+                    if (LatticePreviewUtility.DebugAlignLogs)
+                    {
+                        Debug.LogWarning($"[LatticeProxyUtility] Failed to get member value: {ex.Message}");
+                    }
                     continue;
                 }
 
@@ -158,8 +166,12 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                 {
                     value = method.Invoke(session, null);
                 }
-                catch
+                catch (Exception ex)
                 {
+                    if (LatticePreviewUtility.DebugAlignLogs)
+                    {
+                        Debug.LogWarning($"[LatticeProxyUtility] Failed to invoke method '{method.Name}': {ex.Message}");
+                    }
                     continue;
                 }
 
@@ -291,8 +303,12 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
             {
                 return prop.GetValue(null);
             }
-            catch
+            catch (Exception ex)
             {
+                if (LatticePreviewUtility.DebugAlignLogs)
+                {
+                    Debug.LogWarning($"[LatticeProxyUtility] Failed to get current session: {ex.Message}");
+                }
                 return null;
             }
         }
@@ -315,9 +331,9 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                         return type;
                     }
                 }
-                catch
+                catch (Exception)
                 {
-                    // ignore
+                    // Expected: Some assemblies may not allow type resolution
                 }
             }
 

--- a/Runtime/LatticeAsset.cs
+++ b/Runtime/LatticeAsset.cs
@@ -17,6 +17,7 @@ namespace Net._32Ba.LatticeDeformationTool
     public class LatticeAsset : ISerializationCallbackReceiver
     {
         private const int k_MinAxisResolution = 2;
+        private const int k_MaxRelaxIterations = 16;
 
         [SerializeField]
         private Vector3Int _gridSize = new Vector3Int(3, 3, 3);
@@ -50,8 +51,6 @@ namespace Net._32Ba.LatticeDeformationTool
             get => _interpolation;
             set => _interpolation = value;
         }
-
-        public bool UseJobsAndBurst => true;
 
         public int ControlPointCount => _gridSize.x * _gridSize.y * _gridSize.z;
 
@@ -186,7 +185,7 @@ namespace Net._32Ba.LatticeDeformationTool
                 return;
             }
 
-            iterations = Mathf.Min(iterations, 16);
+            iterations = Mathf.Min(iterations, k_MaxRelaxIterations);
 
             var working = _controlPointsLocal;
             var buffer = new Vector3[count];

--- a/Runtime/LatticeDeformer.cs
+++ b/Runtime/LatticeDeformer.cs
@@ -20,6 +20,11 @@ namespace Net._32Ba.LatticeDeformationTool
             Mode3_BoundsRemap = 2
         }
 
+        /// <summary>
+        /// Batch size for Unity Jobs parallel processing.
+        /// </summary>
+        private const int k_JobBatchSize = 64;
+
         [SerializeField] private LatticeAsset _settings = new LatticeAsset();
         [SerializeField] private SkinnedMeshRenderer _skinnedMeshRenderer;
         [SerializeField] private MeshFilter _meshFilter;
@@ -496,7 +501,7 @@ namespace Net._32Ba.LatticeDeformationTool
                 Result = outputNative
             };
 
-            job.Schedule(entries.Length, 64).Complete();
+            job.Schedule(entries.Length, k_JobBatchSize).Complete();
 
             var vertices = new Vector3[entries.Length];
             outputNative.CopyToManaged(vertices);
@@ -524,7 +529,7 @@ namespace Net._32Ba.LatticeDeformationTool
                 Entries = entriesNative
             };
 
-            job.Schedule(restVertices.Length, 64).Complete();
+            job.Schedule(restVertices.Length, k_JobBatchSize).Complete();
 
             var entries = new LatticeCacheEntry[entriesNative.Length];
             entriesNative.CopyToManaged(entries);
@@ -586,95 +591,6 @@ namespace Net._32Ba.LatticeDeformationTool
 
             _cache.Populate(gridSize, bounds, settings.Interpolation, vertexCount, entries, restVertices);
             return true;
-        }
-
-        private static Vector3 CalculateNormalizedCoordinate(Bounds bounds, Vector3 point)
-        {
-            var size = bounds.size;
-            var min = bounds.min;
-
-            float nx = size.x > Mathf.Epsilon ? (point.x - min.x) / size.x : 0f;
-            float ny = size.y > Mathf.Epsilon ? (point.y - min.y) / size.y : 0f;
-            float nz = size.z > Mathf.Epsilon ? (point.z - min.z) / size.z : 0f;
-
-            return new Vector3(Mathf.Clamp01(nx), Mathf.Clamp01(ny), Mathf.Clamp01(nz));
-        }
-
-        private static LatticeCacheEntry BuildTrilinearEntry(Vector3Int gridSize, Vector3 barycentric)
-        {
-            var grid = new int3(gridSize.x, gridSize.y, gridSize.z);
-
-            float3 scaled = new float3(
-                math.clamp(barycentric.x * (grid.x - 1), 0f, grid.x - 1),
-                math.clamp(barycentric.y * (grid.y - 1), 0f, grid.y - 1),
-                math.clamp(barycentric.z * (grid.z - 1), 0f, grid.z - 1));
-
-            int ix = math.min((int)math.floor(scaled.x), grid.x - 2);
-            int iy = math.min((int)math.floor(scaled.y), grid.y - 2);
-            int iz = math.min((int)math.floor(scaled.z), grid.z - 2);
-
-            float tx = math.saturate(scaled.x - ix);
-            float ty = math.saturate(scaled.y - iy);
-            float tz = math.saturate(scaled.z - iz);
-
-            int nx = grid.x;
-            int ny = grid.y;
-
-            int Index(int x, int y, int z) => x + y * nx + z * nx * ny;
-
-            int c000 = Index(ix, iy, iz);
-            int c100 = Index(ix + 1, iy, iz);
-            int c010 = Index(ix, iy + 1, iz);
-            int c110 = Index(ix + 1, iy + 1, iz);
-            int c001 = Index(ix, iy, iz + 1);
-            int c101 = Index(ix + 1, iy, iz + 1);
-            int c011 = Index(ix, iy + 1, iz + 1);
-            int c111 = Index(ix + 1, iy + 1, iz + 1);
-
-            float tx1 = 1f - tx;
-            float ty1 = 1f - ty;
-            float tz1 = 1f - tz;
-
-            float w000 = tx1 * ty1 * tz1;
-            float w100 = tx * ty1 * tz1;
-            float w010 = tx1 * ty * tz1;
-            float w110 = tx * ty * tz1;
-            float w001 = tx1 * ty1 * tz;
-            float w101 = tx * ty1 * tz;
-            float w011 = tx1 * ty * tz;
-            float w111 = tx * ty * tz;
-
-            return new LatticeCacheEntry
-            {
-                Corner0 = c000,
-                Corner1 = c100,
-                Corner2 = c010,
-                Corner3 = c110,
-                Corner4 = c001,
-                Corner5 = c101,
-                Corner6 = c011,
-                Corner7 = c111,
-                Weights0 = new float4(w000, w100, w010, w110),
-                Weights1 = new float4(w001, w101, w011, w111),
-                Barycentric = new float3(tx, ty, tz)
-            };
-        }
-
-        private static Bounds TransformBounds(Matrix4x4 matrix, Bounds bounds)
-        {
-            var center = matrix.MultiplyPoint3x4(bounds.center);
-            var extents = bounds.extents;
-
-            var axisX = matrix.MultiplyVector(new Vector3(extents.x, 0f, 0f));
-            var axisY = matrix.MultiplyVector(new Vector3(0f, extents.y, 0f));
-            var axisZ = matrix.MultiplyVector(new Vector3(0f, 0f, extents.z));
-
-            var halfSize = new Vector3(
-                Mathf.Abs(axisX.x) + Mathf.Abs(axisY.x) + Mathf.Abs(axisZ.x),
-                Mathf.Abs(axisX.y) + Mathf.Abs(axisY.y) + Mathf.Abs(axisZ.y),
-                Mathf.Abs(axisX.z) + Mathf.Abs(axisY.z) + Mathf.Abs(axisZ.z));
-
-            return new Bounds(center, halfSize * 2f);
         }
 
         [BurstCompile]


### PR DESCRIPTION
## 概要
コードの保守性を向上させるためのリファクタリングを行いました。

## 変更内容

### 1. 共通ユーティリティクラスの追加
- `LatticeBoundsUtility.cs` を新規作成し、重複していたバウンディングボックス関連のメソッドを統合
  - `DivideByScale`: スケールで割るメソッド
  - `AreApproximatelyEqual`: 近似比較
  - `Encapsulate`: バウンズ結合
  - `MapPointBetweenBounds`: バウンズ間の座標マッピング
  - `MapDeltaBetweenBounds`: バウンズ間のデルタマッピング

### 2. マジックナンバーの定数化
- `LatticeTool.cs`: `k_BoundsTolerance`, `k_MaxVolumeRatio`, `k_HandleSizeMultiplier` を追加
- `LatticeDeformer.cs`: `k_JobBatchSize = 64` を追加
- `LatticeAsset.cs`: `k_MaxRelaxIterations = 16` を追加

### 3. 例外処理の改善
- 空の `catch` ブロックに適切なエラーハンドリングを追加
- `LatticeDeformerEditor.cs`, `LatticeDeformerPreviewFilter.cs` のエラー処理を改善

### 4. 未使用コードの削除
- `LatticeDeformer.cs`: `CalculateNormalizedCoordinate`, `BuildTrilinearEntry`, `TransformBounds` メソッドを削除
- `LatticeAsset.cs`: 未使用の `UseJobsAndBurst` プロパティを削除

## テスト計画
- [ ] Unity Editor でプロジェクトがコンパイルエラーなく動作することを確認
- [ ] 格子変形機能が正常に動作することを確認
- [ ] NDMF プレビュー機能が正常に動作することを確認