### PR TITLE
Fix lattice cage center position by changing default alignment mode

### DIFF
--- a/Runtime/LatticeDeformer.cs
+++ b/Runtime/LatticeDeformer.cs
@@ -32,7 +32,7 @@ namespace Net._32Ba.LatticeDeformationTool
         [SerializeField, HideInInspector] private Mesh _serializedSourceMesh;
 
         // Preview alignment (per-instance)
-        [SerializeField, HideInInspector] private LatticeAlignMode _alignMode = LatticeAlignMode.Mode3_BoundsRemap;
+        [SerializeField, HideInInspector] private LatticeAlignMode _alignMode = LatticeAlignMode.Mode1_TransformOnly;
         [SerializeField, HideInInspector] private float _centerClampMulXY = 0f;
         [SerializeField, HideInInspector] private float _centerClampMinXY = 0f;
         [SerializeField, HideInInspector] private float _centerClampMulZ = 0f;


### PR DESCRIPTION
問題:
デフォルト値（manualOffset=zero, manualScale=one）でラティスケージの センター位置がずれていた。

根本原因:
デフォルトのアライメントモードが Mode3_BoundsRemap に設定されており、
sourceとproxyのメッシュバウンズが異なる場合（スケール変換やポーズ違いなど）、
自動的にバウンズリマップが適用されていた。これにより、デフォルト値でも
不要な変換処理が実行され、ケージ位置がずれていた。

修正:
デフォルトのアライメントモードを Mode1_TransformOnly に変更。
これにより、デフォルトでは単純な座標変換のみが適用され、
バウンズリマップは実行されない。ユーザーは必要に応じて
InspectorでMode2やMode3に変更可能。