### PR TITLE
Fix initial lattice bounds when Mesh.bounds is stale

### DIFF
--- a/Runtime/LatticeDeformer.cs
+++ b/Runtime/LatticeDeformer.cs
@@ -311,7 +311,7 @@ namespace Net._32Ba.LatticeDeformationTool
                 return;
             }
 
-            var meshBounds = _sourceMesh.bounds;
+            var meshBounds = CalculateMeshVertexBounds(_sourceMesh);
             settings.LocalBounds = meshBounds;
 
             if (resetControlPoints)
@@ -343,6 +343,33 @@ namespace Net._32Ba.LatticeDeformationTool
             }
 
             _settings.EnsureInitialized();
+        }
+
+        private static Bounds CalculateMeshVertexBounds(Mesh mesh)
+        {
+            if (mesh == null || mesh.vertexCount <= 0)
+            {
+                return default;
+            }
+
+            var vertices = mesh.vertices;
+            if (vertices == null || vertices.Length == 0)
+            {
+                return mesh.bounds;
+            }
+
+            var min = vertices[0];
+            var max = vertices[0];
+
+            for (int i = 1; i < vertices.Length; i++)
+            {
+                min = Vector3.Min(min, vertices[i]);
+                max = Vector3.Max(max, vertices[i]);
+            }
+
+            var bounds = new Bounds(min, Vector3.zero);
+            bounds.SetMinMax(min, max);
+            return bounds;
         }
 
         private void CacheSourceMesh()


### PR DESCRIPTION
## Summary
- initialize lattice bounds from the mesh vertex positions instead of trusting Mesh.bounds
- avoid clamping vertices to an undersized initial cage when imported or generated bounds are stale
- keep Reset Lattice Cage on the same corrected initialization path

## Why
Some meshes can have stale or undersized Mesh.bounds. When LatticeDeformer used those bounds for first-time setup, vertices outside the box were clamped during cache generation, so assigning the component could move the mesh before any control points were edited.

## Validation
- reviewed the affected initialization path in Runtime/LatticeDeformer.cs
- could not complete live Unity verification from this environment because the target Unity project was already open and the local Unity MCP bridge was not available to this client during the check