### PR TITLE
[codex] ビルド時に無効化された Deformer を除外

### DIFF
--- a/Editor/MeshDeformer/Build/MeshDeformerNDMFPlugin.cs
+++ b/Editor/MeshDeformer/Build/MeshDeformerNDMFPlugin.cs
@@ -50,7 +50,7 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
 
         private static void ProcessDeformer(BuildContext context, LatticeDeformer deformer)
         {
-            if (deformer == null)
+            if (!ShouldProcessDeformer(deformer))
             {
                 return;
             }
@@ -130,6 +130,11 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
             }
 
             Object.DestroyImmediate(deformer, true);
+        }
+
+        internal static bool ShouldProcessDeformer(LatticeDeformer deformer)
+        {
+            return deformer != null && deformer.isActiveAndEnabled;
         }
     }
 }

--- a/Editor/MeshDeformer/Build/MeshDeformerNDMFPlugin.cs
+++ b/Editor/MeshDeformer/Build/MeshDeformerNDMFPlugin.cs
@@ -134,7 +134,7 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
 
         internal static bool ShouldProcessDeformer(LatticeDeformer deformer)
         {
-            return deformer != null && deformer.isActiveAndEnabled;
+            return deformer != null && deformer.enabled;
         }
     }
 }

--- a/Tests/Editor/LatticeDeformerBakePassTests.cs
+++ b/Tests/Editor/LatticeDeformerBakePassTests.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR
 using Net._32Ba.LatticeDeformationTool.Editor;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 
 namespace Net._32Ba.LatticeDeformationTool.Tests.Editor
@@ -16,6 +17,26 @@ namespace Net._32Ba.LatticeDeformationTool.Tests.Editor
                 var deformer = go.AddComponent<LatticeDeformer>();
                 deformer.enabled = false;
 
+                Assert.That(LatticeDeformerBakePass.ShouldProcessDeformer(deformer), Is.False);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void ShouldProcessDeformer_WhenInspectorEnabledCheckboxIsUnchecked_ReturnsFalse()
+        {
+            var go = new GameObject("InspectorDisabledComponentDeformer");
+            try
+            {
+                var deformer = go.AddComponent<LatticeDeformer>();
+                var serializedDeformer = new SerializedObject(deformer);
+                serializedDeformer.FindProperty("m_Enabled").boolValue = false;
+                serializedDeformer.ApplyModifiedPropertiesWithoutUndo();
+
+                Assert.That(deformer.enabled, Is.False);
                 Assert.That(LatticeDeformerBakePass.ShouldProcessDeformer(deformer), Is.False);
             }
             finally

--- a/Tests/Editor/LatticeDeformerBakePassTests.cs
+++ b/Tests/Editor/LatticeDeformerBakePassTests.cs
@@ -25,7 +25,7 @@ namespace Net._32Ba.LatticeDeformationTool.Tests.Editor
         }
 
         [Test]
-        public void ShouldProcessDeformer_WhenGameObjectIsInactive_ReturnsFalse()
+        public void ShouldProcessDeformer_WhenGameObjectIsInactive_ReturnsTrue()
         {
             var go = new GameObject("InactiveObjectDeformer");
             try
@@ -33,7 +33,7 @@ namespace Net._32Ba.LatticeDeformationTool.Tests.Editor
                 var deformer = go.AddComponent<LatticeDeformer>();
                 go.SetActive(false);
 
-                Assert.That(LatticeDeformerBakePass.ShouldProcessDeformer(deformer), Is.False);
+                Assert.That(LatticeDeformerBakePass.ShouldProcessDeformer(deformer), Is.True);
             }
             finally
             {

--- a/Tests/Editor/LatticeDeformerBakePassTests.cs
+++ b/Tests/Editor/LatticeDeformerBakePassTests.cs
@@ -1,0 +1,61 @@
+#if UNITY_EDITOR
+using Net._32Ba.LatticeDeformationTool.Editor;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Net._32Ba.LatticeDeformationTool.Tests.Editor
+{
+    public sealed class LatticeDeformerBakePassTests
+    {
+        [Test]
+        public void ShouldProcessDeformer_WhenComponentCheckboxIsOff_ReturnsFalse()
+        {
+            var go = new GameObject("DisabledComponentDeformer");
+            try
+            {
+                var deformer = go.AddComponent<LatticeDeformer>();
+                deformer.enabled = false;
+
+                Assert.That(LatticeDeformerBakePass.ShouldProcessDeformer(deformer), Is.False);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void ShouldProcessDeformer_WhenGameObjectIsInactive_ReturnsFalse()
+        {
+            var go = new GameObject("InactiveObjectDeformer");
+            try
+            {
+                var deformer = go.AddComponent<LatticeDeformer>();
+                go.SetActive(false);
+
+                Assert.That(LatticeDeformerBakePass.ShouldProcessDeformer(deformer), Is.False);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void ShouldProcessDeformer_WhenActiveAndEnabled_ReturnsTrue()
+        {
+            var go = new GameObject("ActiveDeformer");
+            try
+            {
+                var deformer = go.AddComponent<LatticeDeformer>();
+
+                Assert.That(LatticeDeformerBakePass.ShouldProcessDeformer(deformer), Is.True);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+    }
+}
+#endif

--- a/Tests/Editor/LatticeDeformerBakePassTests.cs.meta
+++ b/Tests/Editor/LatticeDeformerBakePassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cab7c5016f4e4905b5a8ed5bfd03fbd6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/net.32ba.lattice-deformation-tool.tests.editor.asmdef
+++ b/Tests/Editor/net.32ba.lattice-deformation-tool.tests.editor.asmdef
@@ -2,7 +2,8 @@
   "name": "net.32ba.lattice-deformation-tool.tests.editor",
   "references": [
     "net.32ba.lattice-deformation-tool",
-    "net.32ba.lattice-deformation-tool.editor"
+    "net.32ba.lattice-deformation-tool.editor",
+    "nadena.dev.ndmf"
   ],
   "includePlatforms": [
     "Editor"


### PR DESCRIPTION
## 変更内容

- NDMF の bake pass で、`LatticeDeformer` コンポーネント自体が無効化されている場合だけ処理対象から除外するようにしました。
- `GetComponentsInChildren(..., true)` の既存挙動に合わせ、非アクティブな GameObject 階層配下でも、コンポーネントが有効な deformer は bake 対象として維持します。これはアバターのトグル運用を壊さないためです。
- コンポーネントのチェックボックスが off の場合、Inspector の `m_Enabled` が serialized state として off の場合、GameObject が非アクティブの場合、通常の有効状態の場合をカバーする EditMode 回帰テストを追加しました。
- bake pass のテストから NDMF の pass 型を直接扱えるように、Editor テスト asmdef に `nadena.dev.ndmf` 参照を追加しました。

## 背景

Inspector で無効化された deformer は、ユーザーがその変形をビルド結果に含めない意図を示している状態です。そのため、コンポーネントのチェックボックスが外れている `LatticeDeformer` がビルド時に mesh へ焼き込まれるのは回帰です。

一方で、非アクティブな GameObject は別扱いです。アバターでは optional mesh をデフォルト非表示にして、後からトグルで有効化する運用が一般的なので、非アクティブ階層配下でもコンポーネント自体が有効な deformer は bake され、ビルド後にコンポーネントが残らない必要があります。

## 原因

bake pass は `GetComponentsInChildren<LatticeDeformer>(true)` で deformer を列挙しています。この API は非アクティブな子 GameObject と無効化されたコンポーネントの両方を含みます。

従来は `null` だけを確認していたため、Inspector のコンポーネントチェックボックスが off の `LatticeDeformer` も `Deform(false)` まで進み、ビルド結果へ反映されていました。

## 影響

ユーザーは Inspector で `LatticeDeformer` コンポーネントを無効化すれば、その変形がビルド結果に反映されないことを期待できます。

同時に、非アクティブな GameObject 上の有効な deformer は従来どおり bake されるため、トグル式のアバターワークフローは維持されます。

## 検証

- Unity MCP EditMode targeted: `Net._32Ba.LatticeDeformationTool.Tests.Editor.LatticeDeformerBakePassTests` 4/4 passed
- Unity MCP EditMode full editor test assembly: `net.32ba.lattice-deformation-tool.tests.editor` 233/233 passed
- `git diff --check` passed