### PR TITLE
[codex] Add hybrid weight transfer mode

### DIFF
--- a/Editor/Legacy/BrushDeformerEditor.cs
+++ b/Editor/Legacy/BrushDeformerEditor.cs
@@ -214,6 +214,11 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
             if (_weightTransferSettingsProp == null) return;
 
             EditorGUILayout.LabelField(LatticeLocalization.Tr(LocKey.Stage1InitialTransfer), EditorStyles.boldLabel);
+            var transferModeProp = _weightTransferSettingsProp.FindPropertyRelative("transferMode");
+            if (transferModeProp != null)
+                EditorGUILayout.PropertyField(transferModeProp, new GUIContent("Transfer Mode",
+                    "Hybrid preserves reliable same-index weights before using surface transfer and inpainting."));
+
             var maxDistProp = _weightTransferSettingsProp.FindPropertyRelative("maxTransferDistance");
             if (maxDistProp != null)
                 EditorGUILayout.PropertyField(maxDistProp, LatticeLocalization.Content(LocKey.MaxTransferDistance,

--- a/Editor/MeshDeformer/Build/MeshDeformerNDMFPlugin.cs
+++ b/Editor/MeshDeformer/Build/MeshDeformerNDMFPlugin.cs
@@ -96,6 +96,7 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                 var settingsData = deformer.WeightTransferSettings;
                 var settings = new WeightTransferSettings
                 {
+                    transferMode = settingsData.transferMode,
                     maxTransferDistance = settingsData.maxTransferDistance,
                     normalAngleThreshold = settingsData.normalAngleThreshold,
                     enableInpainting = settingsData.enableInpainting,

--- a/Editor/MeshDeformer/MeshDeformerEditor.cs
+++ b/Editor/MeshDeformer/MeshDeformerEditor.cs
@@ -1631,6 +1631,16 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
             // Stage 1 settings
             EditorGUILayout.LabelField(LatticeLocalization.Tr(LocKey.Stage1InitialTransfer), EditorStyles.boldLabel);
 
+            var transferModeProp = _weightTransferSettingsProp.FindPropertyRelative("transferMode");
+            if (transferModeProp != null)
+            {
+                EditorGUILayout.PropertyField(
+                    transferModeProp,
+                    new GUIContent(
+                        "Transfer Mode",
+                        "Hybrid preserves reliable same-index weights before using surface transfer and inpainting."));
+            }
+
             var maxDistProp = _weightTransferSettingsProp.FindPropertyRelative("maxTransferDistance");
             if (maxDistProp != null)
             {

--- a/Editor/MeshDeformer/WeightTransfer/RobustWeightTransfer.cs
+++ b/Editor/MeshDeformer/WeightTransfer/RobustWeightTransfer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using Net._32Ba.LatticeDeformationTool;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 
@@ -97,6 +98,7 @@ namespace Net._32Ba.LatticeDeformationTool.Editor.WeightTransfer
             var targetVertices = targetMesh.vertices;
             var targetNormals = targetMesh.normals;
             var targetTriangles = GetAllTriangles(targetMesh);
+            var sourceVertices = sourceMesh.vertices;
             int vertexCount = targetVertices.Length;
 
             var result = new TransferResult
@@ -118,6 +120,23 @@ namespace Net._32Ba.LatticeDeformationTool.Editor.WeightTransfer
 
             var sw = Stopwatch.StartNew();
 
+            // Hybrid mode is for the common same-mesh-before/after case. Vertex index
+            // correspondence is a stronger signal than nearest surface matching, so keep
+            // reliable original weights and use surface transfer only for uncertain vertices.
+            if (settings.transferMode == WeightTransferMode.Hybrid && sourceWeights.Length == vertexCount)
+            {
+                InitializeIndexCorrespondence(
+                    sourceVertices,
+                    sourceMesh.normals,
+                    sourceWeights,
+                    targetVertices,
+                    targetNormals,
+                    settings,
+                    result.weights,
+                    confidenceMask,
+                    ref result.transferredCount);
+            }
+
             // Stage 1: Initial transfer
             Stage1Transfer(
                 sourceMesh,
@@ -133,7 +152,7 @@ namespace Net._32Ba.LatticeDeformationTool.Editor.WeightTransfer
             sw.Restart();
 
             // Stage 2: Weight inpainting (if enabled and needed)
-            if (settings.enableInpainting && result.transferredCount < vertexCount && targetTriangles.Length > 0)
+            if (settings.enableInpainting && HasUnknownVertices(confidenceMask) && targetTriangles.Length > 0)
             {
                 Stage2Inpainting(
                     targetVertices,
@@ -148,7 +167,7 @@ namespace Net._32Ba.LatticeDeformationTool.Editor.WeightTransfer
             var stage2Time = sw.ElapsedMilliseconds;
             Debug.Log($"[WeightTransfer] Stage1: {stage1Time}ms, Stage2: {stage2Time}ms");
 
-            if (!settings.enableInpainting || result.transferredCount >= vertexCount)
+            if (!settings.enableInpainting || !HasUnknownVertices(confidenceMask))
             {
                 // Fill non-transferred vertices with zero weights
                 for (int i = 0; i < vertexCount; i++)
@@ -213,6 +232,54 @@ namespace Net._32Ba.LatticeDeformationTool.Editor.WeightTransfer
         }
 
         /// <summary>
+        /// Initializes reliable same-index weights for source/target meshes with unchanged topology.
+        /// </summary>
+        private static void InitializeIndexCorrespondence(
+            Vector3[] sourceVertices,
+            Vector3[] sourceNormals,
+            BoneWeight[] sourceWeights,
+            Vector3[] targetVertices,
+            Vector3[] targetNormals,
+            WeightTransferSettings settings,
+            BoneWeight[] outWeights,
+            float[] outConfidence,
+            ref int transferredCount)
+        {
+            if (sourceVertices == null || targetVertices == null || sourceVertices.Length != targetVertices.Length)
+            {
+                return;
+            }
+
+            float maxTransferDistance = ResolveMaxTransferDistance(settings, sourceVertices, targetVertices);
+            float safeMaxTransferDistance = Mathf.Max(maxTransferDistance, 1e-6f);
+            float maxDistSq = safeMaxTransferDistance * safeMaxTransferDistance;
+            float normalThresholdCos = Mathf.Cos(settings.normalAngleThreshold * Mathf.Deg2Rad);
+
+            for (int i = 0; i < targetVertices.Length; i++)
+            {
+                if ((targetVertices[i] - sourceVertices[i]).sqrMagnitude > maxDistSq)
+                {
+                    continue;
+                }
+
+                if (sourceNormals != null && targetNormals != null &&
+                    i < sourceNormals.Length && i < targetNormals.Length &&
+                    sourceNormals[i].sqrMagnitude > 1e-8f && targetNormals[i].sqrMagnitude > 1e-8f)
+                {
+                    float normalDot = Vector3.Dot(sourceNormals[i].normalized, targetNormals[i].normalized);
+                    if (normalDot < normalThresholdCos)
+                    {
+                        continue;
+                    }
+                }
+
+                outWeights[i] = sourceWeights[i];
+                outConfidence[i] = 1f;
+                transferredCount++;
+            }
+        }
+
+        /// <summary>
         /// Stage 1: Initial weight transfer based on closest point on source mesh.
         /// Uses batch processing with Burst jobs for performance.
         /// </summary>
@@ -243,6 +310,11 @@ namespace Net._32Ba.LatticeDeformationTool.Editor.WeightTransfer
 
                 for (int i = 0; i < targetVertices.Length; i++)
                 {
+                    if (outConfidence[i] >= 0.5f)
+                    {
+                        continue;
+                    }
+
                     var queryResult = queryResults[i];
                     var targetPos = targetVertices[i];
                     var targetNormal = targetNormals != null && i < targetNormals.Length
@@ -289,6 +361,24 @@ namespace Net._32Ba.LatticeDeformationTool.Editor.WeightTransfer
                     transferredCount++;
                 }
             }
+        }
+
+        private static bool HasUnknownVertices(float[] confidence)
+        {
+            if (confidence == null)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < confidence.Length; i++)
+            {
+                if (confidence[i] < 0.5f)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static int[] GetAllTriangles(Mesh mesh)

--- a/Editor/MeshDeformer/WeightTransfer/WeightTransferSettings.cs
+++ b/Editor/MeshDeformer/WeightTransfer/WeightTransferSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using Net._32Ba.LatticeDeformationTool;
 using UnityEngine;
 
 namespace Net._32Ba.LatticeDeformationTool.Editor.WeightTransfer
@@ -10,6 +11,9 @@ namespace Net._32Ba.LatticeDeformationTool.Editor.WeightTransfer
     [Serializable]
     public class WeightTransferSettings
     {
+        [Tooltip("How bone weights are transferred. Hybrid preserves reliable same-index weights before using surface transfer and inpainting.")]
+        public WeightTransferMode transferMode = WeightTransferMode.Hybrid;
+
         [Header("Stage 1: Initial Transfer")]
         [Tooltip("Maximum transfer distance as a fraction of the target mesh bounds diagonal (paper default: 0.05). May expand based on deformation magnitude.")]
         [Range(0.001f, 1.0f)]
@@ -43,6 +47,7 @@ namespace Net._32Ba.LatticeDeformationTool.Editor.WeightTransfer
         {
             return new WeightTransferSettings
             {
+                transferMode = this.transferMode,
                 maxTransferDistance = this.maxTransferDistance,
                 normalAngleThreshold = this.normalAngleThreshold,
                 enableInpainting = this.enableInpainting,

--- a/Runtime/MeshDeformer/WeightTransferSettingsData.cs
+++ b/Runtime/MeshDeformer/WeightTransferSettingsData.cs
@@ -3,6 +3,12 @@ using UnityEngine;
 
 namespace Net._32Ba.LatticeDeformationTool
 {
+    public enum WeightTransferMode
+    {
+        Hybrid = 0,
+        SurfaceTransfer = 1
+    }
+
     /// <summary>
     /// Serializable settings data for weight transfer operations.
     /// This class is in Runtime so it can be serialized with LatticeDeformer.
@@ -11,6 +17,9 @@ namespace Net._32Ba.LatticeDeformationTool
     [Serializable]
     public class WeightTransferSettingsData
     {
+        [Tooltip("How bone weights are transferred. Hybrid preserves reliable same-index weights before using surface transfer and inpainting.")]
+        public WeightTransferMode transferMode = WeightTransferMode.Hybrid;
+
         [Header("Stage 1: Initial Transfer")]
         [Tooltip("Maximum transfer distance as a fraction of the target mesh bounds diagonal (paper default: 0.05). May expand based on deformation magnitude.")]
         [Range(0.001f, 1.0f)]
@@ -43,6 +52,7 @@ namespace Net._32Ba.LatticeDeformationTool
         {
             return new WeightTransferSettingsData
             {
+                transferMode = this.transferMode,
                 maxTransferDistance = this.maxTransferDistance,
                 normalAngleThreshold = this.normalAngleThreshold,
                 enableInpainting = this.enableInpainting,

--- a/Tests/Editor/RobustWeightTransferTests.cs
+++ b/Tests/Editor/RobustWeightTransferTests.cs
@@ -1,0 +1,201 @@
+#if UNITY_EDITOR
+using Net._32Ba.LatticeDeformationTool;
+using Net._32Ba.LatticeDeformationTool.Editor.WeightTransfer;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Net._32Ba.LatticeDeformationTool.Tests.Editor
+{
+    public sealed class RobustWeightTransferTests
+    {
+        [Test]
+        public void HybridTransfer_PreservesSameIndexWeight_WhenNearestSurfaceWouldUseDifferentIsland()
+        {
+            var source = CreateParallelQuads();
+            var target = Object.Instantiate(source);
+            try
+            {
+                var vertices = target.vertices;
+                vertices[0] = new Vector3(vertices[0].x, vertices[0].y, 0.018f);
+                target.vertices = vertices;
+                target.RecalculateBounds();
+
+                var sourceWeights = CreateParallelQuadWeights();
+                var surfaceSettings = new WeightTransferSettings
+                {
+                    transferMode = WeightTransferMode.SurfaceTransfer,
+                    maxTransferDistance = 1f,
+                    normalAngleThreshold = 180f,
+                    enableInpainting = false
+                };
+                var hybridSettings = surfaceSettings.Clone();
+                hybridSettings.transferMode = WeightTransferMode.Hybrid;
+
+                var surface = RobustWeightTransfer.Transfer(source, sourceWeights, target, surfaceSettings);
+                var hybrid = RobustWeightTransfer.Transfer(source, sourceWeights, target, hybridSettings);
+
+                Assert.That(surface.success, Is.True);
+                Assert.That(hybrid.success, Is.True);
+                Assert.That(DominantBone(surface.weights[0]), Is.EqualTo(1),
+                    "Pure surface transfer should follow the closest parallel surface in this fixture.");
+                Assert.That(DominantBone(hybrid.weights[0]), Is.EqualTo(0),
+                    "Hybrid transfer should keep the reliable same-index source weight.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(source);
+                Object.DestroyImmediate(target);
+            }
+        }
+
+        [Test]
+        public void HybridTransfer_InpaintsOnlyUnreliableSameIndexVertices()
+        {
+            var source = CreateSingleQuad();
+            var target = Object.Instantiate(source);
+            try
+            {
+                var vertices = target.vertices;
+                vertices[0] += Vector3.forward * 10f;
+                target.vertices = vertices;
+                target.RecalculateBounds();
+
+                var sourceWeights = new[]
+                {
+                    BoneWeightFor(2),
+                    BoneWeightFor(0),
+                    BoneWeightFor(1),
+                    BoneWeightFor(1)
+                };
+                var settings = new WeightTransferSettings
+                {
+                    transferMode = WeightTransferMode.Hybrid,
+                    maxTransferDistance = 0.001f,
+                    normalAngleThreshold = 180f,
+                    enableInpainting = true,
+                    maxIterations = 200,
+                    tolerance = 1e-6f
+                };
+
+                var result = RobustWeightTransfer.Transfer(source, sourceWeights, target, settings);
+
+                Assert.That(result.success, Is.True);
+                Assert.That(result.inpaintedCount, Is.EqualTo(1));
+                Assert.That(TotalWeight(result.weights[0]), Is.EqualTo(1f).Within(1e-4f));
+                Assert.That(DominantBone(result.weights[0]), Is.Not.EqualTo(2),
+                    "The unreliable moved vertex should be solved from neighbors, not fall back to its original source weight.");
+                Assert.That(TotalWeight(result.weights[1]), Is.EqualTo(1f).Within(1e-4f));
+                Assert.That(DominantBone(result.weights[1]), Is.EqualTo(0),
+                    "Reliable same-index vertices should remain fixed while the moved vertex is solved.");
+            }
+            finally
+            {
+                Object.DestroyImmediate(source);
+                Object.DestroyImmediate(target);
+            }
+        }
+
+        private static Mesh CreateParallelQuads()
+        {
+            var mesh = new Mesh { name = "ParallelQuads" };
+            mesh.vertices = new[]
+            {
+                new Vector3(-0.5f, -0.5f, 0f),
+                new Vector3(0.5f, -0.5f, 0f),
+                new Vector3(0.5f, 0.5f, 0f),
+                new Vector3(-0.5f, 0.5f, 0f),
+                new Vector3(-0.5f, -0.5f, 0.02f),
+                new Vector3(0.5f, -0.5f, 0.02f),
+                new Vector3(0.5f, 0.5f, 0.02f),
+                new Vector3(-0.5f, 0.5f, 0.02f)
+            };
+            mesh.normals = new[]
+            {
+                Vector3.forward,
+                Vector3.forward,
+                Vector3.forward,
+                Vector3.forward,
+                Vector3.forward,
+                Vector3.forward,
+                Vector3.forward,
+                Vector3.forward
+            };
+            mesh.triangles = new[]
+            {
+                0, 1, 2, 0, 2, 3,
+                4, 5, 6, 4, 6, 7
+            };
+            mesh.RecalculateBounds();
+            return mesh;
+        }
+
+        private static Mesh CreateSingleQuad()
+        {
+            var mesh = new Mesh { name = "SingleQuad" };
+            mesh.vertices = new[]
+            {
+                new Vector3(-0.5f, -0.5f, 0f),
+                new Vector3(0.5f, -0.5f, 0f),
+                new Vector3(0.5f, 0.5f, 0f),
+                new Vector3(-0.5f, 0.5f, 0f)
+            };
+            mesh.normals = new[]
+            {
+                Vector3.forward,
+                Vector3.forward,
+                Vector3.forward,
+                Vector3.forward
+            };
+            mesh.triangles = new[] { 0, 1, 2, 0, 2, 3 };
+            mesh.RecalculateBounds();
+            return mesh;
+        }
+
+        private static BoneWeight[] CreateParallelQuadWeights()
+        {
+            return new[]
+            {
+                BoneWeightFor(0),
+                BoneWeightFor(0),
+                BoneWeightFor(0),
+                BoneWeightFor(0),
+                BoneWeightFor(1),
+                BoneWeightFor(1),
+                BoneWeightFor(1),
+                BoneWeightFor(1)
+            };
+        }
+
+        private static BoneWeight BoneWeightFor(int boneIndex)
+        {
+            return new BoneWeight { boneIndex0 = boneIndex, weight0 = 1f };
+        }
+
+        private static int DominantBone(BoneWeight weight)
+        {
+            int bone = weight.boneIndex0;
+            float max = weight.weight0;
+            if (weight.weight1 > max)
+            {
+                bone = weight.boneIndex1;
+                max = weight.weight1;
+            }
+            if (weight.weight2 > max)
+            {
+                bone = weight.boneIndex2;
+                max = weight.weight2;
+            }
+            if (weight.weight3 > max)
+            {
+                bone = weight.boneIndex3;
+            }
+            return bone;
+        }
+
+        private static float TotalWeight(BoneWeight weight)
+        {
+            return weight.weight0 + weight.weight1 + weight.weight2 + weight.weight3;
+        }
+    }
+}
+#endif

--- a/Tests/Editor/RobustWeightTransferTests.cs.meta
+++ b/Tests/Editor/RobustWeightTransferTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b1f9e7e3b4d4d53a86c7f2c9e2a1f0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要

同一メッシュの変形前後でボーンウェイトを再計算する際に、頂点 index 対応を優先する `Hybrid` 転送モードを追加しました。

## 変更内容

- `WeightTransferMode` を追加し、既定を `Hybrid` に設定
- Hybrid モードでは、信頼できる同一 index 頂点の元ウェイトを保持
- 信頼できない頂点のみ既存の最近傍表面転写と inpainting に流すように変更
- Inspector のウェイト転送設定に `Transfer Mode` を追加
- Hybrid の誤転写抑制と inpainting 対象限定を検証する Editor テストを追加

## 背景

最近傍表面転写だけを使うと、同一メッシュ変形では近接した別 island や別表面へ誤転写する可能性があります。同一 topology では頂点 index 対応がより強い手がかりになるため、これを prior として使う Hybrid モードにしました。

## 検証

UnityMCP 経由で EditMode テストを実行しました。

- `net.32ba.lattice-deformation-tool.tests.editor`: 235 / 235 passed
- `RobustWeightTransferTests`: 2 / 2 passed