### PR TITLE
[codex] Fix blendshape-aware preview mesh deformation

### DIFF
--- a/Editor/MeshDeformer/Preview/MeshDeformerPreviewFilter.cs
+++ b/Editor/MeshDeformer/Preview/MeshDeformerPreviewFilter.cs
@@ -275,6 +275,7 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                     _previewMesh.tangents = tangents;
                 }
 
+                CopyBlendShapes(runtimeMesh, _previewMesh);
                 _previewMesh.bounds = runtimeMesh.bounds;
                 _previewMesh.UploadMeshData(false);
 
@@ -355,6 +356,33 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
             catch
             {
                 return null;
+            }
+        }
+
+        private static void CopyBlendShapes(Mesh source, Mesh destination)
+        {
+            if (source == null || destination == null || source.vertexCount != destination.vertexCount)
+            {
+                return;
+            }
+
+            destination.ClearBlendShapes();
+
+            int shapeCount = source.blendShapeCount;
+            int vertexCount = source.vertexCount;
+            for (int shape = 0; shape < shapeCount; shape++)
+            {
+                string shapeName = source.GetBlendShapeName(shape);
+                int frameCount = source.GetBlendShapeFrameCount(shape);
+                for (int frame = 0; frame < frameCount; frame++)
+                {
+                    float frameWeight = source.GetBlendShapeFrameWeight(shape, frame);
+                    var deltaVertices = new Vector3[vertexCount];
+                    var deltaNormals = new Vector3[vertexCount];
+                    var deltaTangents = new Vector3[vertexCount];
+                    source.GetBlendShapeFrameVertices(shape, frame, deltaVertices, deltaNormals, deltaTangents);
+                    destination.AddBlendShapeFrame(shapeName, frameWeight, deltaVertices, deltaNormals, deltaTangents);
+                }
             }
         }
 

--- a/Editor/MeshDeformer/Tools/LatticeLayerTool.cs
+++ b/Editor/MeshDeformer/Tools/LatticeLayerTool.cs
@@ -626,7 +626,8 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                             }
 
                             deformer.InvalidateCache();
-                            deformer.Deform(false);
+                            bool assignRuntimeMesh = LatticePreviewUtility.ShouldAssignRuntimeMesh();
+                            deformer.Deform(assignRuntimeMesh);
                             LatticePrefabUtility.MarkModified(deformer);
                             LatticePreviewUtility.RequestSceneRepaint();
                         }
@@ -644,7 +645,8 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
                 return;
             }
 
-            _activeDeformer.Deform(false);
+            bool assignRuntimeMesh = LatticePreviewUtility.ShouldAssignRuntimeMesh();
+            _activeDeformer.Deform(assignRuntimeMesh);
 
             LatticePreviewUtility.RequestSceneRepaint();
         }

--- a/Editor/MeshDeformer/Utilities/MeshDeformerPreviewUtility.cs
+++ b/Editor/MeshDeformer/Utilities/MeshDeformerPreviewUtility.cs
@@ -247,18 +247,163 @@ namespace Net._32Ba.LatticeDeformationTool.Editor
             switch (renderer)
             {
                 case SkinnedMeshRenderer skinned:
-                    // localBounds is the skinned renderer's evaluated local AABB (reflects root bone & import settings)
-                    return skinned.localBounds;
+                    return CalculateSkinnedMeshLocalBounds(skinned);
                 case MeshRenderer meshRenderer:
                     var mf = meshRenderer.GetComponent<MeshFilter>();
                     if (mf != null && mf.sharedMesh != null)
                     {
-                        return mf.sharedMesh.bounds;
+                        return CalculateReferencedMeshBounds(mf.sharedMesh, mf.sharedMesh.vertices, mf.sharedMesh.bounds);
                     }
                     break;
             }
 
             return renderer.bounds;
+        }
+
+        private static Bounds CalculateSkinnedMeshLocalBounds(SkinnedMeshRenderer skinned)
+        {
+            var mesh = skinned != null ? skinned.sharedMesh : null;
+            if (mesh == null)
+            {
+                return skinned != null ? skinned.localBounds : new Bounds(Vector3.zero, Vector3.zero);
+            }
+
+            var vertices = mesh.vertices;
+            if (vertices == null || vertices.Length == 0)
+            {
+                return mesh.bounds;
+            }
+
+            if (mesh.blendShapeCount > 0)
+            {
+                int shapeCount = mesh.blendShapeCount;
+                for (int shape = 0; shape < shapeCount; shape++)
+                {
+                    float weight = skinned.GetBlendShapeWeight(shape);
+                    if (Mathf.Abs(weight) <= 1e-5f)
+                    {
+                        continue;
+                    }
+
+                    var delta = EvaluateBlendShapeVertexDelta(mesh, shape, weight);
+                    if (delta == null || delta.Length != vertices.Length)
+                    {
+                        continue;
+                    }
+
+                    for (int i = 0; i < vertices.Length; i++)
+                    {
+                        vertices[i] += delta[i];
+                    }
+                }
+            }
+
+            return CalculateReferencedMeshBounds(mesh, vertices, mesh.bounds);
+        }
+
+        private static Vector3[] EvaluateBlendShapeVertexDelta(Mesh mesh, int shapeIndex, float weight)
+        {
+            int frameCount = mesh.GetBlendShapeFrameCount(shapeIndex);
+            if (frameCount <= 0)
+            {
+                return null;
+            }
+
+            int vertexCount = mesh.vertexCount;
+            var lower = new Vector3[vertexCount];
+            var upper = new Vector3[vertexCount];
+            var normals = new Vector3[vertexCount];
+            var tangents = new Vector3[vertexCount];
+
+            float firstWeight = mesh.GetBlendShapeFrameWeight(shapeIndex, 0);
+            if (weight <= firstWeight || frameCount == 1)
+            {
+                mesh.GetBlendShapeFrameVertices(shapeIndex, 0, lower, normals, tangents);
+                float scale = Mathf.Abs(firstWeight) > Mathf.Epsilon ? weight / firstWeight : 0f;
+                for (int i = 0; i < lower.Length; i++)
+                {
+                    lower[i] *= scale;
+                }
+
+                return lower;
+            }
+
+            for (int frame = 1; frame < frameCount; frame++)
+            {
+                float upperWeight = mesh.GetBlendShapeFrameWeight(shapeIndex, frame);
+                if (weight <= upperWeight)
+                {
+                    float lowerWeight = mesh.GetBlendShapeFrameWeight(shapeIndex, frame - 1);
+                    mesh.GetBlendShapeFrameVertices(shapeIndex, frame - 1, lower, normals, tangents);
+                    mesh.GetBlendShapeFrameVertices(shapeIndex, frame, upper, normals, tangents);
+
+                    float t = Mathf.Abs(upperWeight - lowerWeight) > Mathf.Epsilon
+                        ? Mathf.InverseLerp(lowerWeight, upperWeight, weight)
+                        : 0f;
+                    for (int i = 0; i < lower.Length; i++)
+                    {
+                        lower[i] = Vector3.LerpUnclamped(lower[i], upper[i], t);
+                    }
+
+                    return lower;
+                }
+            }
+
+            mesh.GetBlendShapeFrameVertices(shapeIndex, frameCount - 1, lower, normals, tangents);
+            return lower;
+        }
+
+        private static Bounds CalculateReferencedMeshBounds(Mesh mesh, Vector3[] vertices, Bounds fallback)
+        {
+            if (mesh == null || vertices == null || vertices.Length == 0)
+            {
+                return fallback;
+            }
+
+            var bounds = new Bounds();
+            bool hasPoint = false;
+
+            int subMeshCount = Mathf.Max(1, mesh.subMeshCount);
+            for (int subMesh = 0; subMesh < subMeshCount; subMesh++)
+            {
+                var indices = mesh.GetIndices(subMesh);
+                if (indices == null)
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < indices.Length; i++)
+                {
+                    int vertexIndex = indices[i];
+                    if (vertexIndex < 0 || vertexIndex >= vertices.Length)
+                    {
+                        continue;
+                    }
+
+                    if (!hasPoint)
+                    {
+                        bounds = new Bounds(vertices[vertexIndex], Vector3.zero);
+                        hasPoint = true;
+                    }
+                    else
+                    {
+                        bounds.Encapsulate(vertices[vertexIndex]);
+                    }
+                }
+            }
+
+            if (hasPoint)
+            {
+                return bounds;
+            }
+
+            bounds = new Bounds(vertices[0], Vector3.zero);
+            for (int i = 1; i < vertices.Length; i++)
+            {
+                bounds.Encapsulate(vertices[i]);
+            }
+
+            return bounds;
         }
 
         internal static Bounds GetRendererLocalBounds(Renderer renderer)

--- a/Runtime/MeshDeformer/LatticeDeformer.cs
+++ b/Runtime/MeshDeformer/LatticeDeformer.cs
@@ -1277,7 +1277,10 @@ namespace Net._32Ba.LatticeDeformationTool
                 return null;
             }
 
-            var sourceVertices = BuildCurrentSourceVertices(out var bakedBlendShapeDeltas, out var bakedBlendShapeHash);
+            var sourceVertices = BuildCurrentSourceVertices(
+                out var bakedBlendShapeDeltas,
+                out var bakedBlendShapeWeights,
+                out var bakedBlendShapeHash);
             if (sourceVertices == null || sourceVertices.Length == 0)
             {
                 return null;
@@ -1350,7 +1353,7 @@ namespace Net._32Ba.LatticeDeformationTool
                     _lastBlendShapeHash = blendShapeHash;
 
                     mesh.ClearBlendShapes();
-                    CopyBlendShapes(_sourceMesh, mesh, bakedBlendShapeDeltas);
+                    CopyBlendShapes(_sourceMesh, mesh, bakedBlendShapeDeltas, bakedBlendShapeWeights);
 
                     const int sampleCount = 100;
                     foreach (var (group, deltas) in blendShapeGroups)
@@ -1379,13 +1382,13 @@ namespace Net._32Ba.LatticeDeformationTool
                 if (_lastBlendShapeHash != 0)
                 {
                     mesh.ClearBlendShapes();
-                    CopyBlendShapes(_sourceMesh, mesh, bakedBlendShapeDeltas);
+                    CopyBlendShapes(_sourceMesh, mesh, bakedBlendShapeDeltas, bakedBlendShapeWeights);
                     _lastBlendShapeHash = 0;
                 }
                 else if (bakedBlendShapeHash != _lastBakedBlendShapeHash)
                 {
                     mesh.ClearBlendShapes();
-                    CopyBlendShapes(_sourceMesh, mesh, bakedBlendShapeDeltas);
+                    CopyBlendShapes(_sourceMesh, mesh, bakedBlendShapeDeltas, bakedBlendShapeWeights);
                 }
             }
 
@@ -1489,7 +1492,11 @@ namespace Net._32Ba.LatticeDeformationTool
             return hash;
         }
 
-        private static void CopyBlendShapes(Mesh source, Mesh destination, Vector3[][] bakedBlendShapeDeltas = null)
+        private static void CopyBlendShapes(
+            Mesh source,
+            Mesh destination,
+            Vector3[][] bakedBlendShapeDeltas = null,
+            float[] bakedBlendShapeWeights = null)
         {
             int shapeCount = source.blendShapeCount;
             int vertexCount = source.vertexCount;
@@ -1497,6 +1504,28 @@ namespace Net._32Ba.LatticeDeformationTool
             {
                 string name = source.GetBlendShapeName(s);
                 int frameCount = source.GetBlendShapeFrameCount(s);
+                var baked = bakedBlendShapeDeltas != null && s < bakedBlendShapeDeltas.Length
+                    ? bakedBlendShapeDeltas[s]
+                    : null;
+                float bakedWeight = bakedBlendShapeWeights != null && s < bakedBlendShapeWeights.Length
+                    ? bakedBlendShapeWeights[s]
+                    : 0f;
+                bool hasBakedShape = baked != null && baked.Length == vertexCount;
+
+                if (hasBakedShape && frameCount > 0)
+                {
+                    float firstWeight = source.GetBlendShapeFrameWeight(s, 0);
+                    if (bakedWeight < firstWeight - 1e-5f)
+                    {
+                        destination.AddBlendShapeFrame(
+                            name,
+                            bakedWeight,
+                            new Vector3[vertexCount],
+                            new Vector3[vertexCount],
+                            new Vector3[vertexCount]);
+                    }
+                }
+
                 for (int f = 0; f < frameCount; f++)
                 {
                     float weight = source.GetBlendShapeFrameWeight(s, f);
@@ -1504,10 +1533,7 @@ namespace Net._32Ba.LatticeDeformationTool
                     var dn = new Vector3[vertexCount];
                     var dt = new Vector3[vertexCount];
                     source.GetBlendShapeFrameVertices(s, f, dv, dn, dt);
-                    var baked = bakedBlendShapeDeltas != null && s < bakedBlendShapeDeltas.Length
-                        ? bakedBlendShapeDeltas[s]
-                        : null;
-                    if (baked != null && baked.Length == vertexCount)
+                    if (hasBakedShape)
                     {
                         for (int v = 0; v < vertexCount; v++)
                         {
@@ -1520,9 +1546,13 @@ namespace Net._32Ba.LatticeDeformationTool
             }
         }
 
-        private Vector3[] BuildCurrentSourceVertices(out Vector3[][] bakedBlendShapeDeltas, out int bakedBlendShapeHash)
+        private Vector3[] BuildCurrentSourceVertices(
+            out Vector3[][] bakedBlendShapeDeltas,
+            out float[] bakedBlendShapeWeights,
+            out int bakedBlendShapeHash)
         {
             bakedBlendShapeDeltas = null;
+            bakedBlendShapeWeights = null;
             bakedBlendShapeHash = 0;
 
             if (_sourceMesh == null)
@@ -1549,6 +1579,7 @@ namespace Net._32Ba.LatticeDeformationTool
             }
 
             Vector3[][] deltas = null;
+            float[] weights = null;
             bool hasBakedShape = false;
             int hash = 17;
 
@@ -1567,7 +1598,9 @@ namespace Net._32Ba.LatticeDeformationTool
                 }
 
                 deltas ??= new Vector3[shapeCount][];
+                weights ??= new float[shapeCount];
                 deltas[s] = delta;
+                weights[s] = weight;
                 hasBakedShape = true;
                 hash = HashCode.Combine(hash, s, weight);
 
@@ -1583,6 +1616,7 @@ namespace Net._32Ba.LatticeDeformationTool
             }
 
             bakedBlendShapeDeltas = deltas;
+            bakedBlendShapeWeights = weights;
             bakedBlendShapeHash = hash;
             return vertices;
         }
@@ -1680,7 +1714,7 @@ namespace Net._32Ba.LatticeDeformationTool
             EnsureGroups();
             if (_sourceMesh == null) return;
 
-            var sourceVertices = BuildCurrentSourceVertices(out _, out _);
+            var sourceVertices = BuildCurrentSourceVertices(out _, out _, out _);
             var meshBounds = CalculateReferencedBounds(_sourceMesh, sourceVertices, _sourceMesh.bounds);
             foreach (var group in _groups)
             {

--- a/Runtime/MeshDeformer/LatticeDeformer.cs
+++ b/Runtime/MeshDeformer/LatticeDeformer.cs
@@ -369,6 +369,7 @@ namespace Net._32Ba.LatticeDeformationTool
         [NonSerialized] private Mesh _runtimeMesh;
         [NonSerialized] private Mesh _sourceMesh;
         [NonSerialized] private int _lastBlendShapeHash;
+        [NonSerialized] private int _lastBakedBlendShapeHash;
         private const int k_CurrentLayerModelVersion = 3;
         private const string k_PrimaryLayerName = "Lattice Layer";
         private const string k_BrushLayerName = "Brush Layer";
@@ -1276,7 +1277,7 @@ namespace Net._32Ba.LatticeDeformationTool
                 return null;
             }
 
-            var sourceVertices = _sourceMesh.vertices;
+            var sourceVertices = BuildCurrentSourceVertices(out var bakedBlendShapeDeltas, out var bakedBlendShapeHash);
             if (sourceVertices == null || sourceVertices.Length == 0)
             {
                 return null;
@@ -1342,14 +1343,14 @@ namespace Net._32Ba.LatticeDeformationTool
             // Handle BlendShape output
             if (blendShapeGroups.Count > 0)
             {
-                int blendShapeHash = ComputeBlendShapeOutputHash(blendShapeGroups);
+                int blendShapeHash = HashCode.Combine(ComputeBlendShapeOutputHash(blendShapeGroups), bakedBlendShapeHash);
                 if (blendShapeHash != _lastBlendShapeHash)
                 {
                     UnityEngine.Profiling.Profiler.BeginSample("LatticeDeformer.RebuildBlendShapes");
                     _lastBlendShapeHash = blendShapeHash;
 
                     mesh.ClearBlendShapes();
-                    CopyBlendShapes(_sourceMesh, mesh);
+                    CopyBlendShapes(_sourceMesh, mesh, bakedBlendShapeDeltas);
 
                     const int sampleCount = 100;
                     foreach (var (group, deltas) in blendShapeGroups)
@@ -1378,10 +1379,17 @@ namespace Net._32Ba.LatticeDeformationTool
                 if (_lastBlendShapeHash != 0)
                 {
                     mesh.ClearBlendShapes();
-                    CopyBlendShapes(_sourceMesh, mesh);
+                    CopyBlendShapes(_sourceMesh, mesh, bakedBlendShapeDeltas);
                     _lastBlendShapeHash = 0;
                 }
+                else if (bakedBlendShapeHash != _lastBakedBlendShapeHash)
+                {
+                    mesh.ClearBlendShapes();
+                    CopyBlendShapes(_sourceMesh, mesh, bakedBlendShapeDeltas);
+                }
             }
+
+            _lastBakedBlendShapeHash = bakedBlendShapeHash;
 
             mesh.vertices = finalVertices;
 
@@ -1442,7 +1450,7 @@ namespace Net._32Ba.LatticeDeformationTool
             }
 
             var layerSettings = layer.Settings;
-            if (layerSettings == null || !EnsureCache(layerSettings))
+            if (layerSettings == null || !EnsureCache(layerSettings, sourceVertices))
             {
                 return;
             }
@@ -1481,7 +1489,7 @@ namespace Net._32Ba.LatticeDeformationTool
             return hash;
         }
 
-        private static void CopyBlendShapes(Mesh source, Mesh destination)
+        private static void CopyBlendShapes(Mesh source, Mesh destination, Vector3[][] bakedBlendShapeDeltas = null)
         {
             int shapeCount = source.blendShapeCount;
             int vertexCount = source.vertexCount;
@@ -1496,8 +1504,147 @@ namespace Net._32Ba.LatticeDeformationTool
                     var dn = new Vector3[vertexCount];
                     var dt = new Vector3[vertexCount];
                     source.GetBlendShapeFrameVertices(s, f, dv, dn, dt);
+                    var baked = bakedBlendShapeDeltas != null && s < bakedBlendShapeDeltas.Length
+                        ? bakedBlendShapeDeltas[s]
+                        : null;
+                    if (baked != null && baked.Length == vertexCount)
+                    {
+                        for (int v = 0; v < vertexCount; v++)
+                        {
+                            dv[v] -= baked[v];
+                        }
+                    }
+
                     destination.AddBlendShapeFrame(name, weight, dv, dn, dt);
                 }
+            }
+        }
+
+        private Vector3[] BuildCurrentSourceVertices(out Vector3[][] bakedBlendShapeDeltas, out int bakedBlendShapeHash)
+        {
+            bakedBlendShapeDeltas = null;
+            bakedBlendShapeHash = 0;
+
+            if (_sourceMesh == null)
+            {
+                return null;
+            }
+
+            var vertices = _sourceMesh.vertices;
+            if (vertices == null || vertices.Length == 0)
+            {
+                return vertices;
+            }
+
+            if (_skinnedMeshRenderer == null || _sourceMesh.blendShapeCount == 0)
+            {
+                return vertices;
+            }
+
+            int shapeCount = _sourceMesh.blendShapeCount;
+            int vertexCount = _sourceMesh.vertexCount;
+            if (vertices.Length != vertexCount)
+            {
+                return vertices;
+            }
+
+            Vector3[][] deltas = null;
+            bool hasBakedShape = false;
+            int hash = 17;
+
+            for (int s = 0; s < shapeCount; s++)
+            {
+                float weight = _skinnedMeshRenderer.GetBlendShapeWeight(s);
+                if (Mathf.Abs(weight) <= 1e-5f)
+                {
+                    continue;
+                }
+
+                var delta = EvaluateBlendShapeVertexDelta(_sourceMesh, s, weight);
+                if (delta == null)
+                {
+                    continue;
+                }
+
+                deltas ??= new Vector3[shapeCount][];
+                deltas[s] = delta;
+                hasBakedShape = true;
+                hash = HashCode.Combine(hash, s, weight);
+
+                for (int v = 0; v < vertexCount; v++)
+                {
+                    vertices[v] += delta[v];
+                }
+            }
+
+            if (!hasBakedShape)
+            {
+                return vertices;
+            }
+
+            bakedBlendShapeDeltas = deltas;
+            bakedBlendShapeHash = hash;
+            return vertices;
+        }
+
+        private static Vector3[] EvaluateBlendShapeVertexDelta(Mesh mesh, int shapeIndex, float weight)
+        {
+            int frameCount = mesh.GetBlendShapeFrameCount(shapeIndex);
+            if (frameCount <= 0)
+            {
+                return null;
+            }
+
+            int vertexCount = mesh.vertexCount;
+            var lower = new Vector3[vertexCount];
+            var upper = new Vector3[vertexCount];
+            var unusedNormals = new Vector3[vertexCount];
+            var unusedTangents = new Vector3[vertexCount];
+
+            float firstWeight = mesh.GetBlendShapeFrameWeight(shapeIndex, 0);
+            if (weight <= firstWeight || frameCount == 1)
+            {
+                mesh.GetBlendShapeFrameVertices(shapeIndex, 0, lower, unusedNormals, unusedTangents);
+                float scale = Mathf.Abs(firstWeight) > Mathf.Epsilon ? weight / firstWeight : 0f;
+                ScaleDeltas(lower, scale);
+                return lower;
+            }
+
+            for (int frame = 1; frame < frameCount; frame++)
+            {
+                float upperWeight = mesh.GetBlendShapeFrameWeight(shapeIndex, frame);
+                if (weight <= upperWeight)
+                {
+                    float lowerWeight = mesh.GetBlendShapeFrameWeight(shapeIndex, frame - 1);
+                    mesh.GetBlendShapeFrameVertices(shapeIndex, frame - 1, lower, unusedNormals, unusedTangents);
+                    mesh.GetBlendShapeFrameVertices(shapeIndex, frame, upper, unusedNormals, unusedTangents);
+
+                    float t = Mathf.Abs(upperWeight - lowerWeight) > Mathf.Epsilon
+                        ? Mathf.InverseLerp(lowerWeight, upperWeight, weight)
+                        : 0f;
+                    for (int i = 0; i < vertexCount; i++)
+                    {
+                        lower[i] = Vector3.LerpUnclamped(lower[i], upper[i], t);
+                    }
+
+                    return lower;
+                }
+            }
+
+            mesh.GetBlendShapeFrameVertices(shapeIndex, frameCount - 1, lower, unusedNormals, unusedTangents);
+            return lower;
+        }
+
+        private static void ScaleDeltas(Vector3[] deltas, float scale)
+        {
+            if (deltas == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < deltas.Length; i++)
+            {
+                deltas[i] *= scale;
             }
         }
 
@@ -1533,7 +1680,8 @@ namespace Net._32Ba.LatticeDeformationTool
             EnsureGroups();
             if (_sourceMesh == null) return;
 
-            var meshBounds = _sourceMesh.bounds;
+            var sourceVertices = BuildCurrentSourceVertices(out _, out _);
+            var meshBounds = CalculateReferencedBounds(_sourceMesh, sourceVertices, _sourceMesh.bounds);
             foreach (var group in _groups)
             {
                 if (group == null) continue;
@@ -2005,6 +2153,8 @@ namespace Net._32Ba.LatticeDeformationTool
                 _runtimeMesh = Instantiate(_sourceMesh);
                 _runtimeMesh.name = _sourceMesh.name + " (Mesh Deformer)";
                 _runtimeMesh.hideFlags = HideFlags.HideAndDontSave;
+                _lastBlendShapeHash = 0;
+                _lastBakedBlendShapeHash = int.MinValue;
             }
 
             if (assignToRenderer)
@@ -2045,6 +2195,8 @@ namespace Net._32Ba.LatticeDeformationTool
             }
 
             _runtimeMesh = null;
+            _lastBlendShapeHash = 0;
+            _lastBakedBlendShapeHash = int.MinValue;
         }
 
         private void EnsureControlBuffer(int controlPointCount)
@@ -2136,7 +2288,7 @@ namespace Net._32Ba.LatticeDeformationTool
         }
 
 
-        private bool EnsureCache(LatticeAsset settings)
+        private bool EnsureCache(LatticeAsset settings, Vector3[] restVertices)
         {
             if (settings == null)
             {
@@ -2154,17 +2306,18 @@ namespace Net._32Ba.LatticeDeformationTool
                 return false;
             }
 
-            if (_cache.IsCompatibleWith(settings, mesh))
+            int restVerticesHash = HashVertices(restVertices);
+            if (_cache.IsCompatibleWith(settings, mesh, restVerticesHash))
             {
                 return true;
             }
 
-            return RebuildCache(settings, mesh);
+            return RebuildCache(settings, mesh, restVertices, restVerticesHash);
         }
 
-        private bool RebuildCache(LatticeAsset settings, Mesh mesh)
+        private bool RebuildCache(LatticeAsset settings, Mesh mesh, Vector3[] restVertices, int restVerticesHash)
         {
-            if (settings == null || mesh == null)
+            if (settings == null || mesh == null || restVertices == null)
             {
                 return false;
             }
@@ -2182,14 +2335,83 @@ namespace Net._32Ba.LatticeDeformationTool
                 return false;
             }
 
-            var restVertices = mesh.vertices;
             var bounds = settings.LocalBounds;
             LatticeCacheEntry[] entries;
 
             entries = BuildCacheWithJobs(gridSize, bounds, restVertices);
 
-            _cache.Populate(gridSize, bounds, settings.Interpolation, vertexCount, entries, restVertices);
+            _cache.Populate(gridSize, bounds, settings.Interpolation, vertexCount, restVerticesHash, entries, restVertices);
             return true;
+        }
+
+        private static Bounds CalculateReferencedBounds(Mesh mesh, Vector3[] vertices, Bounds fallback)
+        {
+            if (mesh == null || vertices == null || vertices.Length == 0)
+            {
+                return fallback;
+            }
+
+            var bounds = new Bounds();
+            bool hasPoint = false;
+
+            int subMeshCount = Mathf.Max(1, mesh.subMeshCount);
+            for (int subMesh = 0; subMesh < subMeshCount; subMesh++)
+            {
+                var indices = mesh.GetIndices(subMesh);
+                if (indices == null)
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < indices.Length; i++)
+                {
+                    int vertexIndex = indices[i];
+                    if (vertexIndex < 0 || vertexIndex >= vertices.Length)
+                    {
+                        continue;
+                    }
+
+                    if (!hasPoint)
+                    {
+                        bounds = new Bounds(vertices[vertexIndex], Vector3.zero);
+                        hasPoint = true;
+                    }
+                    else
+                    {
+                        bounds.Encapsulate(vertices[vertexIndex]);
+                    }
+                }
+            }
+
+            if (hasPoint)
+            {
+                return bounds;
+            }
+
+            bounds = new Bounds(vertices[0], Vector3.zero);
+            for (int i = 1; i < vertices.Length; i++)
+            {
+                bounds.Encapsulate(vertices[i]);
+            }
+
+            return bounds;
+        }
+
+        private static int HashVertices(Vector3[] vertices)
+        {
+            if (vertices == null || vertices.Length == 0)
+            {
+                return 0;
+            }
+
+            int hash = vertices.Length;
+            for (int i = 0; i < vertices.Length; i++)
+            {
+                var v = vertices[i];
+                hash = HashCode.Combine(hash, v.x, v.y, v.z);
+            }
+
+            return hash;
         }
 
         private static Vector3 CalculateNormalizedCoordinate(Bounds bounds, Vector3 point)
@@ -2408,12 +2630,13 @@ namespace Net._32Ba.LatticeDeformationTool
         [SerializeField] private Bounds _localBounds;
         [SerializeField] private LatticeInterpolationMode _interpolation;
         [SerializeField] private int _vertexCount;
+        [SerializeField] private int _restVerticesHash;
         [SerializeField] private LatticeCacheEntry[] _entries = Array.Empty<LatticeCacheEntry>();
         [SerializeField] private Vector3[] _restVertices = Array.Empty<Vector3>();
 
         public LatticeCacheEntry[] Entries => _entries;
 
-        public bool IsCompatibleWith(LatticeAsset asset, Mesh mesh)
+        public bool IsCompatibleWith(LatticeAsset asset, Mesh mesh, int restVerticesHash)
         {
             if (asset == null || mesh == null)
             {
@@ -2426,6 +2649,11 @@ namespace Net._32Ba.LatticeDeformationTool
             }
 
             if (_vertexCount != mesh.vertexCount)
+            {
+                return false;
+            }
+
+            if (_restVerticesHash != restVerticesHash)
             {
                 return false;
             }
@@ -2448,12 +2676,13 @@ namespace Net._32Ba.LatticeDeformationTool
             return true;
         }
 
-        public void Populate(Vector3Int gridSize, Bounds bounds, LatticeInterpolationMode interpolation, int vertexCount, LatticeCacheEntry[] entries, Vector3[] restVertices)
+        public void Populate(Vector3Int gridSize, Bounds bounds, LatticeInterpolationMode interpolation, int vertexCount, int restVerticesHash, LatticeCacheEntry[] entries, Vector3[] restVertices)
         {
             _gridSize = gridSize;
             _localBounds = bounds;
             _interpolation = interpolation;
             _vertexCount = vertexCount;
+            _restVerticesHash = restVerticesHash;
             _entries = entries ?? Array.Empty<LatticeCacheEntry>();
             _restVertices = restVertices ?? Array.Empty<Vector3>();
         }
@@ -2463,6 +2692,7 @@ namespace Net._32Ba.LatticeDeformationTool
             _entries = Array.Empty<LatticeCacheEntry>();
             _restVertices = Array.Empty<Vector3>();
             _vertexCount = 0;
+            _restVerticesHash = 0;
         }
 
         private static bool ApproximatelyEquals(Bounds lhs, Bounds rhs)

--- a/Tests/Editor/DeformIntegrityAndMiscTests.cs
+++ b/Tests/Editor/DeformIntegrityAndMiscTests.cs
@@ -194,6 +194,93 @@ namespace Net._32Ba.LatticeDeformationTool.Tests.Editor
             finally { fixture.Dispose(); }
         }
 
+        [Test]
+        public void SkinnedBlendShapeWeight_InitializeBoundsUsesVisibleVertices()
+        {
+            var fixture = CreateSkinnedBlendShapeFixture("SkinnedBlendShapeWeight_InitializeBounds");
+            try
+            {
+                var deformer = fixture.Deformer;
+                var source = fixture.SourceMesh;
+                var baseVertices = source.vertices;
+                var deltas = new Vector3[source.vertexCount];
+                source.GetBlendShapeFrameVertices(0, 0, deltas, null, null);
+
+                var referenced = source.triangles;
+                var expected = new Bounds(baseVertices[referenced[0]] + deltas[referenced[0]], Vector3.zero);
+                for (int i = 1; i < referenced.Length; i++)
+                {
+                    int vertexIndex = referenced[i];
+                    expected.Encapsulate(baseVertices[vertexIndex] + deltas[vertexIndex]);
+                }
+
+                deformer.InitializeFromSource(true);
+
+                AssertApproximately(expected.center, deformer.Settings.LocalBounds.center, Epsilon);
+                AssertApproximately(expected.size, deformer.Settings.LocalBounds.size, Epsilon);
+            }
+            finally { fixture.Dispose(); }
+        }
+
+        [Test]
+        public void SkinnedBlendShapeWeight_DeformBakesVisibleVerticesWithoutDoubleApplying()
+        {
+            var fixture = CreateSkinnedBlendShapeFixture("SkinnedBlendShapeWeight_DeformBakesVisible");
+            try
+            {
+                var deformer = fixture.Deformer;
+                var source = fixture.SourceMesh;
+                var runtime = deformer.Deform(false);
+
+                var baseVertices = source.vertices;
+                var sourceDeltas = new Vector3[source.vertexCount];
+                source.GetBlendShapeFrameVertices(0, 0, sourceDeltas, null, null);
+
+                var runtimeDeltas = new Vector3[runtime.vertexCount];
+                runtime.GetBlendShapeFrameVertices(0, 0, runtimeDeltas, null, null);
+                var runtimeVertices = runtime.vertices;
+
+                foreach (int i in source.triangles)
+                {
+                    AssertApproximately(baseVertices[i] + sourceDeltas[i], runtimeVertices[i], Epsilon);
+                    AssertApproximately(Vector3.zero, runtimeDeltas[i], Epsilon);
+                }
+            }
+            finally { fixture.Dispose(); }
+        }
+
+        [Test]
+        public void SkinnedBlendShapeWeight_DeformAfterRestoreStillDoesNotDoubleApply()
+        {
+            var fixture = CreateSkinnedBlendShapeFixture("SkinnedBlendShapeWeight_DeformAfterRestore");
+            try
+            {
+                var deformer = fixture.Deformer;
+                var source = fixture.SourceMesh;
+                var renderer = fixture.Root.GetComponent<SkinnedMeshRenderer>();
+
+                deformer.Deform(true);
+                deformer.RestoreOriginalMesh();
+                var runtime = deformer.Deform(true);
+
+                var baseVertices = source.vertices;
+                var sourceDeltas = new Vector3[source.vertexCount];
+                source.GetBlendShapeFrameVertices(0, 0, sourceDeltas, null, null);
+
+                var runtimeDeltas = new Vector3[runtime.vertexCount];
+                runtime.GetBlendShapeFrameVertices(0, 0, runtimeDeltas, null, null);
+                var runtimeVertices = runtime.vertices;
+
+                Assert.That(renderer.sharedMesh, Is.SameAs(runtime));
+                foreach (int i in source.triangles)
+                {
+                    AssertApproximately(baseVertices[i] + sourceDeltas[i], runtimeVertices[i], Epsilon);
+                    AssertApproximately(Vector3.zero, runtimeDeltas[i], Epsilon);
+                }
+            }
+            finally { fixture.Dispose(); }
+        }
+
         // ========================================================================
         // RestoreOriginalMesh
         // ========================================================================
@@ -1194,6 +1281,41 @@ namespace Net._32Ba.LatticeDeformationTool.Tests.Editor
             deformer.Deform(false);
 
             return new TestFixture(root, sourceMesh, deformer);
+        }
+
+        private static TestFixture CreateSkinnedBlendShapeFixture(string name)
+        {
+            var mesh = new Mesh { name = name + "_Mesh" };
+            mesh.vertices = new[]
+            {
+                new Vector3(0f, 0f, 0f),
+                new Vector3(1f, 0f, 0f),
+                new Vector3(0f, 1f, 0f),
+                new Vector3(100f, 100f, 100f)
+            };
+            mesh.triangles = new[] { 0, 1, 2 };
+            mesh.RecalculateNormals();
+            mesh.RecalculateBounds();
+
+            var deltas = new[]
+            {
+                new Vector3(0f, 0.25f, 0f),
+                new Vector3(0f, 0.25f, 0f),
+                new Vector3(0f, 0.5f, 0f),
+                new Vector3(100f, 100f, 100f)
+            };
+            mesh.AddBlendShapeFrame("ExistingShape", 100f, deltas, null, null);
+
+            var root = new GameObject(name);
+            var smr = root.AddComponent<SkinnedMeshRenderer>();
+            smr.sharedMesh = mesh;
+            smr.SetBlendShapeWeight(0, 100f);
+
+            var deformer = root.AddComponent<LatticeDeformer>();
+            deformer.Reset();
+            deformer.Deform(false);
+
+            return new TestFixture(root, mesh, deformer);
         }
 
         private static Mesh CreateCubeMesh()

--- a/Tests/Editor/DeformIntegrityAndMiscTests.cs
+++ b/Tests/Editor/DeformIntegrityAndMiscTests.cs
@@ -281,6 +281,41 @@ namespace Net._32Ba.LatticeDeformationTool.Tests.Editor
             finally { fixture.Dispose(); }
         }
 
+        [Test]
+        public void SkinnedBlendShapeWeight_PartialWeight_DeformKeepsVisibleShape()
+        {
+            var fixture = CreateSkinnedBlendShapeFixture("SkinnedBlendShapeWeight_PartialWeight", 50f);
+            try
+            {
+                var deformer = fixture.Deformer;
+                var source = fixture.SourceMesh;
+                var renderer = fixture.Root.GetComponent<SkinnedMeshRenderer>();
+                var expectedVisibleVertices = EvaluateVisibleVertices(renderer);
+
+                var runtime = deformer.Deform(true);
+                var actualVisibleVertices = EvaluateVisibleVertices(renderer);
+
+                Assert.That(renderer.sharedMesh, Is.SameAs(runtime));
+                foreach (int i in source.triangles)
+                {
+                    AssertApproximately(expectedVisibleVertices[i], actualVisibleVertices[i], Epsilon);
+                }
+
+                int shapeIndex = runtime.GetBlendShapeIndex("ExistingShape");
+                Assert.That(shapeIndex, Is.GreaterThanOrEqualTo(0));
+                Assert.That(runtime.GetBlendShapeFrameCount(shapeIndex), Is.EqualTo(2));
+                Assert.That(runtime.GetBlendShapeFrameWeight(shapeIndex, 0), Is.EqualTo(50f).Within(Epsilon));
+
+                var neutralDeltas = new Vector3[runtime.vertexCount];
+                runtime.GetBlendShapeFrameVertices(shapeIndex, 0, neutralDeltas, null, null);
+                foreach (int i in source.triangles)
+                {
+                    AssertApproximately(Vector3.zero, neutralDeltas[i], Epsilon);
+                }
+            }
+            finally { fixture.Dispose(); }
+        }
+
         // ========================================================================
         // RestoreOriginalMesh
         // ========================================================================
@@ -1283,7 +1318,7 @@ namespace Net._32Ba.LatticeDeformationTool.Tests.Editor
             return new TestFixture(root, sourceMesh, deformer);
         }
 
-        private static TestFixture CreateSkinnedBlendShapeFixture(string name)
+        private static TestFixture CreateSkinnedBlendShapeFixture(string name, float blendShapeWeight = 100f)
         {
             var mesh = new Mesh { name = name + "_Mesh" };
             mesh.vertices = new[]
@@ -1309,13 +1344,82 @@ namespace Net._32Ba.LatticeDeformationTool.Tests.Editor
             var root = new GameObject(name);
             var smr = root.AddComponent<SkinnedMeshRenderer>();
             smr.sharedMesh = mesh;
-            smr.SetBlendShapeWeight(0, 100f);
+            smr.SetBlendShapeWeight(0, blendShapeWeight);
 
             var deformer = root.AddComponent<LatticeDeformer>();
             deformer.Reset();
             deformer.Deform(false);
 
             return new TestFixture(root, mesh, deformer);
+        }
+
+        private static Vector3[] EvaluateVisibleVertices(SkinnedMeshRenderer renderer)
+        {
+            var mesh = renderer.sharedMesh;
+            var vertices = mesh.vertices;
+            for (int shape = 0; shape < mesh.blendShapeCount; shape++)
+            {
+                var delta = EvaluateBlendShapeVertexDelta(mesh, shape, renderer.GetBlendShapeWeight(shape));
+                if (delta == null) continue;
+                for (int i = 0; i < vertices.Length; i++)
+                {
+                    vertices[i] += delta[i];
+                }
+            }
+
+            return vertices;
+        }
+
+        private static Vector3[] EvaluateBlendShapeVertexDelta(Mesh mesh, int shapeIndex, float weight)
+        {
+            int frameCount = mesh.GetBlendShapeFrameCount(shapeIndex);
+            if (frameCount <= 0)
+            {
+                return null;
+            }
+
+            int vertexCount = mesh.vertexCount;
+            var lower = new Vector3[vertexCount];
+            var upper = new Vector3[vertexCount];
+            var unusedNormals = new Vector3[vertexCount];
+            var unusedTangents = new Vector3[vertexCount];
+
+            float firstWeight = mesh.GetBlendShapeFrameWeight(shapeIndex, 0);
+            if (weight <= firstWeight || frameCount == 1)
+            {
+                mesh.GetBlendShapeFrameVertices(shapeIndex, 0, lower, unusedNormals, unusedTangents);
+                float scale = Mathf.Abs(firstWeight) > Mathf.Epsilon ? weight / firstWeight : 0f;
+                for (int i = 0; i < lower.Length; i++)
+                {
+                    lower[i] *= scale;
+                }
+
+                return lower;
+            }
+
+            for (int frame = 1; frame < frameCount; frame++)
+            {
+                float upperWeight = mesh.GetBlendShapeFrameWeight(shapeIndex, frame);
+                if (weight <= upperWeight)
+                {
+                    float lowerWeight = mesh.GetBlendShapeFrameWeight(shapeIndex, frame - 1);
+                    mesh.GetBlendShapeFrameVertices(shapeIndex, frame - 1, lower, unusedNormals, unusedTangents);
+                    mesh.GetBlendShapeFrameVertices(shapeIndex, frame, upper, unusedNormals, unusedTangents);
+
+                    float t = Mathf.Abs(upperWeight - lowerWeight) > Mathf.Epsilon
+                        ? Mathf.InverseLerp(lowerWeight, upperWeight, weight)
+                        : 0f;
+                    for (int i = 0; i < lower.Length; i++)
+                    {
+                        lower[i] = Vector3.LerpUnclamped(lower[i], upper[i], t);
+                    }
+
+                    return lower;
+                }
+            }
+
+            mesh.GetBlendShapeFrameVertices(shapeIndex, frameCount - 1, lower, unusedNormals, unusedTangents);
+            return lower;
         }
 
         private static Mesh CreateCubeMesh()


### PR DESCRIPTION
## 概要

既存blendshapeが適用されたSkinnedMeshRendererにMesh Deformerを割り当てたときのプレビュー/ランタイムメッシュ処理を修正します。

## 変更内容

- 現在のblendshape weightを反映した頂点をdeformerの入力として扱うように変更
- 既存blendshapeをランタイムメッシュへコピーする際、焼き込み済みの差分を差し引いて二重適用を防止
- ランタイムメッシュ生成/破棄時にblendshape再構築キャッシュを無効化
- Lattice Boxの初期化とプレビュー用bounds計算で、参照されている頂点領域と現在のblendshape weightを考慮
- NDMF previewを使わない状態でもLattice操作後にrendererへランタイムメッシュを割り当てるよう修正
- 上記の回帰テストを追加

## 原因

ランタイムメッシュを破棄した後も、blendshapeの焼き込み状態を表すキャッシュが残っていました。そのため次回のランタイムメッシュ再生成時に、既存blendshapeが調整済みと誤判定され、頂点へ焼き込んだ差分と元のblendshapeが同時に効く場合がありました。

## 確認

- Unity MCPで実シーンの対象SkinnedMeshRendererを確認
  - 修正前: `Deform(true)` のみで `visibleMaxDiff=0.017311`
  - 修正後: `visibleMaxDiff=0.000000`
- EditMode tests
  - `SkinnedBlendShapeWeight_InitializeBoundsUsesVisibleVertices`
  - `SkinnedBlendShapeWeight_DeformBakesVisibleVerticesWithoutDoubleApplying`
  - `SkinnedBlendShapeWeight_DeformAfterRestoreStillDoesNotDoubleApply`
  - 結果: `3/3 passed`